### PR TITLE
Serve Vite client as production build via nginx

### DIFF
--- a/example-bounty-program/client/buildClient.sh
+++ b/example-bounty-program/client/buildClient.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Build the Vite client for a given network mode and output a deployable dist folder.
+# Usage: ./buildClient.sh [base|base-sepolia|both] [output_dir]
+# Default: both, output under ../deploy/www/<net>
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+NETWORK="${1:-both}"
+OUTPUT_DIR="${2:-""}"
+
+build_network() {
+  local net="$1"
+  local out
+
+  if [ -n "$OUTPUT_DIR" ]; then
+    out="$OUTPUT_DIR/$net"
+  else
+    out="../deploy/www/$net"
+  fi
+
+  echo "Building client for mode=$net → $out"
+  rm -rf "$out"
+
+  # Install deps (deterministic)
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
+
+  # Build with Vite mode, output to a network-specific folder
+  npx vite build --mode "$net" --outDir "$out"
+
+  echo "Built $net client: $out"
+}
+
+case "$NETWORK" in
+  base)
+    build_network "base"
+    ;;
+  base-sepolia)
+    build_network "base-sepolia"
+    ;;
+  both)
+    build_network "base"
+    build_network "base-sepolia"
+    ;;
+  *)
+    echo "Usage: $0 [base|base-sepolia|both] [output_dir]"
+    exit 1
+    ;;
+esac

--- a/example-bounty-program/deploy/nginx/bounties-testnet.verdikta.org
+++ b/example-bounty-program/deploy/nginx/bounties-testnet.verdikta.org
@@ -2,18 +2,10 @@ server {
     listen 80;
     server_name bounties-testnet.verdikta.org;
 
-    # Testnet client (Base Sepolia)
-    location / {
-        proxy_pass http://localhost:5174;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
+    # Serve the built (production) Vite app directly from disk.
+    # Build output path produced by: client/buildClient.sh base-sepolia
+    root /var/www/verdikta-bounties/base-sepolia;
+    index index.html;
 
     # Testnet API (Base Sepolia)
     location /api/ {
@@ -23,5 +15,17 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|webp|woff2?)$ {
+        try_files $uri =404;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
     }
 }

--- a/example-bounty-program/deploy/nginx/bounties.verdikta.org
+++ b/example-bounty-program/deploy/nginx/bounties.verdikta.org
@@ -2,18 +2,10 @@ server {
     listen 80;
     server_name bounties.verdikta.org;
 
-    # Mainnet client (Base)
-    location / {
-        proxy_pass http://localhost:5173;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
+    # Serve the built (production) Vite app directly from disk.
+    # Build output path produced by: client/buildClient.sh base
+    root /var/www/verdikta-bounties/base;
+    index index.html;
 
     # Mainnet API (Base)
     location /api/ {
@@ -23,5 +15,17 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA routing: serve index.html for all non-file paths
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively (hashed filenames)
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|webp|woff2?)$ {
+        try_files $uri =404;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily production deployment/config changes; misconfigured paths, SPA routing, or caching headers could break client serving or cause stale assets in production.
> 
> **Overview**
> Switches production Nginx setup from proxying to Vite dev servers (`localhost:5173/5174`) to serving **static, built** client assets from `/var/www/verdikta-bounties/{base,base-sepolia}`, while continuing to proxy `/api/` to the appropriate backend.
> 
> Adds `client/buildClient.sh` to produce per-network Vite builds and updates the Nginx configs with SPA `try_files` routing and long-lived caching headers for static assets; deployment docs are updated accordingly (build + rsync to web root, only backend services need to run).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce029ffd9196661912f92cc76b34ed90a7c3b5d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->