### PR TITLE
Enforce classMap jury models and remove stale model guidance

### DIFF
--- a/example-bounty-program/client/src/pages/Agents.jsx
+++ b/example-bounty-program/client/src/pages/Agents.jsx
@@ -1153,11 +1153,9 @@ def finalize_submission(w3, account, job_id, sub_id):
                   is based on the rubric criteria you can read beforehand.
                 </p>
                 <p style={{ marginTop: '0.5rem' }}>
-                  <strong>Supported models:</strong>{' '}
-                  <code>gpt-5.2-2025-12-11</code>, <code>gpt-5-mini-2025-08-07</code> (OpenAI),
-                  and <code>claude-3-5-haiku-20241022</code> (Anthropic).
-                  Bounties using unsupported models (e.g., <code>gpt-4o</code>) will silently fail —
-                  oracles never respond and submissions are stuck permanently.
+                  <strong>Supported models are dynamic.</strong>{' '}
+                  Always fetch the current list from <code>/api/classes/:classId/models</code> before creating a bounty.
+                  Bounties with unsupported models are rejected and may otherwise lead to stuck evaluations.
                   If you are creating bounties, see the{' '}
                   <Link to="/blockchain">Blockchain documentation</Link> for
                   the exact evaluation package template — the query text must be used

--- a/example-bounty-program/server/server.js
+++ b/example-bounty-program/server/server.js
@@ -194,7 +194,10 @@ app.get('/api/classes', (req, res) => {
 
     res.json({
       success: true,
-      classes: serializedClasses
+      classes: serializedClasses,
+      classMapVersion: typeof classMap.getMapVersion === 'function' ? classMap.getMapVersion() : null,
+      source: '@verdikta/common',
+      generatedAt: new Date().toISOString()
     });
   } catch (error) {
     logger.error('Error fetching classes:', error);
@@ -235,7 +238,10 @@ app.get('/api/classes/:classId', (req, res) => {
 
     res.json({
       success: true,
-      class: serializedClass
+      class: serializedClass,
+      classMapVersion: typeof classMap.getMapVersion === 'function' ? classMap.getMapVersion() : null,
+      source: '@verdikta/common',
+      generatedAt: new Date().toISOString()
     });
   } catch (error) {
     logger.error('Error fetching class:', error);
@@ -298,7 +304,10 @@ app.get('/api/classes/:classId/models', (req, res) => {
       status: classInfo.status,
       models: classInfo.models || [],
       modelsByProvider,
-      limits: classInfo.limits || null
+      limits: classInfo.limits || null,
+      classMapVersion: typeof classMap.getMapVersion === 'function' ? classMap.getMapVersion() : null,
+      source: '@verdikta/common',
+      generatedAt: new Date().toISOString()
     };
 
     res.json(response);

--- a/example-bounty-program/server/utils/bountyValidator.js
+++ b/example-bounty-program/server/utils/bountyValidator.js
@@ -294,24 +294,24 @@ async function validateBounty({ evaluationCid, classId, ipfsClient, classMap }) 
         if (!classInfo) {
           issues.push({
             type: IssueType.INVALID_CLASS,
-            severity: IssueSeverity.WARNING,
+            severity: IssueSeverity.ERROR,
             message: `Class ${classId} not found in class map`
           });
         } else if (classInfo.status !== 'ACTIVE') {
           issues.push({
             type: IssueType.INVALID_CLASS,
-            severity: IssueSeverity.WARNING,
+            severity: IssueSeverity.ERROR,
             message: `Class ${classId} is not active (status: ${classInfo.status})`
           });
         } else if (classInfo.models && Array.isArray(classInfo.models)) {
-          const availableModels = classInfo.models.map(m => `${m.provider}/${m.model}`);
+          const availableModels = classInfo.models.map(m => `${String(m.provider || '').toLowerCase()}/${m.model}`);
           for (const node of juryNodes) {
-            const modelKey = `${node.provider}/${node.model}`;
+            const modelKey = `${String(node.provider || '').toLowerCase()}/${node.model}`;
             if (!availableModels.includes(modelKey)) {
               issues.push({
                 type: IssueType.MODEL_UNAVAILABLE,
-                severity: IssueSeverity.WARNING,
-                message: `Jury model ${modelKey} may not be available in class ${classId}`
+                severity: IssueSeverity.ERROR,
+                message: `Jury model ${modelKey} is not available in class ${classId}`
               });
             }
           }

--- a/skills/verdikta-bounties-onboarding/SKILL.md
+++ b/skills/verdikta-bounties-onboarding/SKILL.md
@@ -265,7 +265,7 @@ Create a JSON file (e.g., `bounty.json`) with the bounty details:
   },
   "juryNodes": [
     { "provider": "OpenAI", "model": "gpt-5.2-2025-12-11", "weight": 0.5, "runs": 1 },
-    { "provider": "Anthropic", "model": "claude-3-5-haiku-20241022", "weight": 0.5, "runs": 1 }
+    { "provider": "Anthropic", "model": "claude-sonnet-4-5-20250929", "weight": 0.5, "runs": 1 }
   ]
 }
 ```

--- a/skills/verdikta-bounties-onboarding/references/api_endpoints.md
+++ b/skills/verdikta-bounties-onboarding/references/api_endpoints.md
@@ -47,7 +47,7 @@ Body:
   },
   "juryNodes": [
     { "provider": "OpenAI", "model": "gpt-5.2-2025-12-11", "weight": 0.5, "runs": 1 },
-    { "provider": "Anthropic", "model": "claude-3-5-haiku-20241022", "weight": 0.5, "runs": 1 }
+    { "provider": "Anthropic", "model": "claude-sonnet-4-5-20250929", "weight": 0.5, "runs": 1 }
   ]
 }
 ```


### PR DESCRIPTION
Summary

This PR makes @verdikta/common class maps the strict source of truth for allowed jury models, and removes stale/hardcoded model references that can cause deprecated model usage.

Why

We observed deprecated model usage (e.g. claude-3-5-haiku-20241022) still being accepted in some flows due to stale docs/examples and non-blocking validation. This causes stuck evaluations and unreliable agent behavior.


What changed

Backend (authoritative enforcement)

• POST /api/jobs/create now hard-fails if any juryNodes[{provider, model}] is not in classMap.getClass(classId).models.
• Provider normalization added for comparison (OpenAI/openai, etc).
• Clear 400 payload with:
• classId
• invalidNodes
• allowedModels
• /api/jobs/:jobId/validate treats model unavailability as error (not warning) in strict mode.
Class/model API contract

• Added metadata fields to class endpoints:
• classMapVersion
• source: "@verdikta/common"
• generatedAt
Frontend/docs safety

• Removed hardcoded “supported models” text from Agents page.
• Updated text to point to dynamic class/model endpoints.
• Tightened Create Bounty class-switch behavior to avoid silent jury carryover into unverified classes.
Skill/docs updates

• Added explicit preflight requirement: verify every jury model via /api/classes/:classId/models before create.
• Removed deprecated model examples from agent-facing docs/examples.

API behavior changes (breaking)

POST /api/jobs/create now rejects unsupported jury models with HTTP 400.

Example error
{
"error": "Invalid jury configuration",
"details": "One or more jury models are not supported for this class",
"classId": 128,
"allowedModels": ["openai/gpt-5.2-2025-12-11", "anthropic/claude-sonnet-4-5-20250929"],
"invalidNodes": [
{ "provider": "anthropic", "model": "claude-3-5-haiku-20241022" }
]
}
Files touched

• server/routes/jobRoutes.js
• server/utils/bountyValidator.js
• server/server.js
• server/utils/validation.js (if optional class-aware validation path included)
• client/src/pages/Agents.jsx
• client/src/pages/CreateBounty.jsx
• client/src/services/classMapService.js
• skills/verdikta-bounties-onboarding/SKILL.md (or equivalent docs location)
• skills/verdikta-bounties-onboarding/references/api_endpoints.md
• skills/verdikta-bounties-onboarding/references/classes-models-and-agent-api.md

Test plan

Backend tests

• [ ] Create with valid models for class 128 succeeds.
• [ ] Create with deprecated/unsupported model fails with 400 + invalidNodes.
• [ ] /api/jobs/:jobId/validate reports unsupported model as ERROR.
• [ ] /api/classes, /api/classes/:id, /api/classes/:id/models include classMapVersion.
Frontend/manual tests

• [ ] Agents page no longer shows hardcoded stale model names.
• [ ] Create flow blocks invalid jury model/class combos.
• [ ] Class switching does not silently preserve incompatible jury nodes.
Regression checks

• [ ] Existing valid bounty creation flow remains unchanged.
• [ ] Submission/claim flows unaffected for valid bounties.

Rollout notes

• Announce to integrators: create API is now strict on jury model membership.
• Recommend all agents run preflight:
1. GET /api/classes/:classId/models
2. verify juryNodes membership
3. call POST /api/jobs/create

Optional follow-up (separate PR)

Add POST /api/classes/:classId/jury/validate to provide a dedicated preflight endpoint for agents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking behavior change by rejecting previously accepted jury configurations at create-time and tightening validation severity; risk is primarily integration/compatibility rather than data or auth.
> 
> **Overview**
> `POST /api/jobs/create` now **strictly validates** `juryNodes` against the active class’s supported models from `@verdikta/common` (with provider name normalization), returning a 400 with `invalidNodes` and `allowedModels` instead of allowing potentially stuck evaluations.
> 
> Class endpoints (`/api/classes`, `/api/classes/:id`, `/api/classes/:id/models`) now include metadata (`classMapVersion`, `source`, `generatedAt`) to support clients caching/diagnostics, and bounty validation escalates class/model mismatches from *warnings* to **errors**.
> 
> Frontend/docs remove hardcoded “supported models” lists and point creators to fetch models dynamically from `/api/classes/:classId/models`, and onboarding examples swap a deprecated Anthropic model for a current one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3932fa20931460fa0baca846a32164c3ebaad5dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->