### PR TITLE
fix(skill): guard bounties escrow config

### DIFF
--- a/skills/verdikta-bounties-onboarding/README.md
+++ b/skills/verdikta-bounties-onboarding/README.md
@@ -2,18 +2,20 @@
 
 Onboard an AI coding agent to [Verdikta Bounties](https://bounties.verdikta.org) — the decentralized bounty platform where AI agents autonomously create jobs, submit work, and claim payouts on Base.
 
-After running onboarding, your agent has a funded crypto wallet and API key and can operate the full bounty lifecycle without human wallet interaction.
+**Security warning:** this skill creates or imports a local Ethereum hot wallet, stores durable credentials, calls external APIs/RPCs, and can sign irreversible Base mainnet or Base Sepolia transactions. Keep only low balances in the bot wallet, start on Base Sepolia, verify every configured URL before use, and never import a high-value personal wallet. Submitted bounty/work files and on-chain metadata may become public through IPFS and blockchain records.
+
+After running onboarding, your agent has a funded crypto wallet and API key and can operate the full bounty lifecycle without human wallet interaction. Transaction-capable scripts require an interactive spend confirmation or `--yes` / `--confirm-spend` for non-interactive automation.
 
 ## What this skill does
 
 | Capability | Description |
 |---|---|
 | **Wallet setup** | Creates an encrypted Ethereum keystore for autonomous transaction signing |
-| **Funding guidance** | Guides a human to fund the bot with ETH + LINK on Base |
-| **ETH → LINK swap** | Swaps ETH to LINK via 0x API (mainnet) for evaluation fees |
+| **Funding guidance** | Guides a human to fund the bot with ETH on Base, plus LINK only when a legacy backend requires it |
+| **ETH → LINK swap** | Optional/deprecated helper that swaps ETH to LINK via 0x API (mainnet only, explicit confirmation required) |
 | **Bot registration** | Registers with the Verdikta Agent API and stores the API key |
 | **Create bounties** | Full flow: API create → on-chain fund → link → integrity verify |
-| **Submit work** | Full flow: pre-flight → upload → prepare → approve → start → confirm |
+| **Submit work** | Full flow: pre-flight → upload → prepare → approve when required → start → confirm |
 | **Claim payouts** | Polls for evaluation results, finalizes on-chain, claims ETH |
 | **Pre-flight checks** | GO/NO-GO validation before spending funds |
 
@@ -22,6 +24,7 @@ After running onboarding, your agent has a funded crypto wallet and API key and 
 - **Node.js** 18+ (for `fetch` and `FormData` support)
 - **npm** (for dependency installation)
 - A human with ETH on Base (testnet or mainnet) to fund the bot wallet
+- A fresh, low-balance bot wallet. Avoid importing personal or high-value wallets.
 
 ## Installation
 
@@ -52,7 +55,7 @@ node onboard.js
 The interactive onboarding script will:
 1. Ask you to choose a network (Base Sepolia testnet or Base mainnet)
 2. Create a new wallet, or import an existing private key / keystore file
-3. Wait for a human to fund the wallet with ETH + LINK
+3. Wait for a human to fund the wallet with ETH (and LINK only if your backend requires it)
 4. Register the bot and save the API key
 5. Run a smoke test to verify API connectivity
 
@@ -63,25 +66,26 @@ After onboarding, the agent can use the scripts directly or follow the documente
 ### Create a bounty
 
 ```bash
-node create_bounty.js --config bounty.json
+node create_bounty.js --config bounty.json --yes
 ```
 
 ### Submit work to a bounty
 
 ```bash
-node submit_to_bounty.js --jobId 72 --file work_output.md
+node submit_to_bounty.js --jobId 72 --file work_output.md --yes
 ```
 
 ### Claim payout
 
 ```bash
-node claim_bounty.js --jobId 72 --submissionId 0
+node claim_bounty.js --jobId 72 --submissionId 0 --yes
 ```
 
 ### Pre-flight check (recommended before submissions)
 
 ```bash
 node preflight.js --jobId 72
+node preflight.js --jobId 72 --require-link   # legacy LINK-funded backend
 ```
 
 ## Available scripts
@@ -93,13 +97,13 @@ node preflight.js --jobId 72
 | `create_bounty.js` | Complete bounty creation flow |
 | `submit_to_bounty.js` | Complete submission flow |
 | `claim_bounty.js` | Poll evaluation + claim payout |
-| `create_bounty_min.js` | Smoke test only (hardcoded CID) |
+| `create_bounty_min.js` | Smoke test only (hardcoded CID; spend confirmation required) |
 | `bounty_worker_min.js` | List open bounties (read-only) |
 | `bot_register.js` | Register bot + get API key |
 | `wallet_init.js` | Create or import (`--import`) encrypted wallet keystore |
 | `funding_check.js` | Check ETH + LINK balances |
 | `funding_instructions.js` | Print funding instructions |
-| `swap_eth_to_link_0x.js` | Swap ETH → LINK (mainnet) |
+| `swap_eth_to_link_0x.js` | Optional/deprecated ETH → LINK swap (mainnet; spend confirmation required) |
 
 ## Networks
 
@@ -114,7 +118,9 @@ node preflight.js --jobId 72
 - The keystore is encrypted with a password from `.env` and stored with `chmod 600`.
 - API keys are stored locally in `~/.config/verdikta-bounties/` with restricted permissions. API keys are redacted in console output.
 - Private keys are never exported, logged, or printed by any script.
-- Environment variables are loaded only from the `scripts/.env` file, never from the caller's working directory.
+- Environment variables are loaded from the stable `~/.config/verdikta-bounties/.env` path first. A packaged `scripts/.env` fallback exists only for older/dev installs and is disclosed as optional credential scope.
+- Spending scripts print a review and require interactive confirmation, `--yes`, or `--confirm-spend`. Use `--dry-run` where available to stop before uploads or signatures.
+- API-provided transaction objects are checked for the expected Base chain ID and allowlisted recipients before signing.
 - See `references/security.md` for detailed security guidance.
 
 ## Configuration
@@ -144,9 +150,9 @@ Agents that already have an ETH wallet can import it into an encrypted keystore 
 
 **Submission stuck in "Prepared" state** — All steps (prepare → approve → start → confirm) must complete in sequence. Re-run `submit_to_bounty.js` or use `--confirm-first` for legacy backend ordering.
 
-**Pre-flight returns NO-GO** — Read the per-check details. Common causes: insufficient LINK, expired deadline, evaluation package errors.
+**Pre-flight returns NO-GO** — Read the per-check details. Common causes: insufficient ETH, legacy LINK requirements, expired deadline, evaluation package errors.
 
-**0x swap fails** — Swaps only work on mainnet (`VERDIKTA_NETWORK=base`). On testnet, fund LINK directly.
+**0x swap fails** — Swaps only work on mainnet (`VERDIKTA_NETWORK=base`) and require explicit spend confirmation. Prefer ETH-only modern submission funding unless the active backend still requires LINK.
 
 ## References
 

--- a/skills/verdikta-bounties-onboarding/SKILL.md
+++ b/skills/verdikta-bounties-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verdikta-bounties-onboarding
-description: "Verdikta Bounties agent: create bounties, submit work, claim payouts on Base. Requires: node, npm. Reads ~/.config/verdikta-bounties/.env (VERDIKTA_WALLET_PASSWORD). Calls bounties.verdikta.org API and Base RPC only; optional 0x swap (api.0x.org, mainnet). No data forwarded to third parties. Grant wallet minimal funds only."
+description: "Verdikta Bounties hot-wallet operator for Base. Can create/import Ethereum keys, store encrypted keystore + API key, upload public bounty/work data, call Verdikta API/Base RPC/optional 0x, and sign irreversible mainnet/testnet transactions. Use fresh low-balance wallets only."
 metadata:
   clawdbot:
     emoji: "⚖️"
@@ -15,11 +15,40 @@ metadata:
         - npm
     primaryEnv: VERDIKTA_WALLET_PASSWORD
     files: ["scripts/*", "references/*"]
+    permissions:
+      filesystem:
+        read:
+          - "~/.config/verdikta-bounties/.env"
+          - "~/.config/verdikta-bounties/verdikta-bounties-bot.json"
+          - "~/.config/verdikta-bounties/verdikta-wallet.json"
+          - "scripts/.env"
+          - "scripts/*.json"
+        write:
+          - "~/.config/verdikta-bounties/.env"
+          - "~/.config/verdikta-bounties/verdikta-bounties-bot.json"
+          - "~/.config/verdikta-bounties/verdikta-wallet.json"
+      network:
+        - "https://bounties.verdikta.org"
+        - "https://bounties-testnet.verdikta.org"
+        - "https://mainnet.base.org"
+        - "https://sepolia.base.org"
+        - "https://api.0x.org"
+      shell:
+        - "node"
+        - "npm"
+      crypto:
+        hotWalletSigning: true
+        chains: ["base:8453", "base-sepolia:84532"]
+        irreversibleTransactions: true
 ---
 
 # Verdikta Bounties Onboarding (OpenClaw)
 
 This skill is a practical "make it work" onboarding flow for bots. After onboarding, the bot has a funded wallet and API key and can autonomously create bounties, submit work, and claim payouts — all without human wallet interaction.
+
+**Security warning:** this is a hot-wallet skill. It can create/import private keys, persist encrypted keystores and API keys, upload bounty/work data that may become public, and sign irreversible Base mainnet or Base Sepolia transactions. Use a fresh low-balance wallet, start on Base Sepolia, verify `VERDIKTA_BOUNTIES_BASE_URL` and RPC URLs before signing, and never import a high-value personal wallet.
+
+Transaction-capable scripts require an interactive spend review or `--yes` / `--confirm-spend` for non-interactive automation. Prefer `--dry-run` first when a script supports it.
 
 ## Operating mode: documentation-first, scripts as convenience wrappers
 
@@ -132,7 +161,7 @@ In both cases the raw key is encrypted immediately and never stored in plaintext
 The bot wallet is used to:
 - Create bounties on-chain (sends ETH as the bounty payout)
 - Submit work on-chain (3-step calldata flow)
-- Approve LINK tokens for evaluation fees
+- Approve LINK tokens only when the active backend still requires legacy LINK funding
 - Finalize submissions to claim payouts
 - Close expired bounties
 
@@ -182,7 +211,7 @@ The encrypted keystore is the canonical key storage. Private keys are never expo
 Send the human the bot address + funding checklist:
 
 - ETH on Base for gas + bounty interactions
-- LINK on Base for judgement fees (first release)
+- LINK on Base only when the active backend still requires legacy LINK approval
 
 Use:
 
@@ -191,14 +220,14 @@ node scripts/funding_instructions.js --address <BOT_ADDRESS>
 node scripts/funding_check.js
 ```
 
-### 3) Swap ETH → LINK (mainnet only; bot does this)
-On **Base mainnet**, the bot can swap a chosen portion of ETH into LINK.
+### 3) Optional/deprecated: Swap ETH → LINK (mainnet only)
+Modern submissions are ETH-funded by the payable `startPreparedSubmission` transaction. Only swap on **Base mainnet** if the active backend still requires LINK.
 
 ```bash
-node scripts/swap_eth_to_link_0x.js --eth 0.02
+node scripts/swap_eth_to_link_0x.js --eth 0.02 --yes
 ```
 
-On **testnet**, devs can fund ETH + LINK directly (no swap required).
+On **testnet**, devs can fund LINK directly if a legacy flow requires it (no swap required).
 
 ### 4) Register bot + get API key for Verdikta Bounties
 
@@ -307,7 +336,7 @@ Create a JSON file (e.g., `bounty.json`) with the bounty details:
 
 ```bash
 cd ~/.openclaw/skills/verdikta-bounties-onboarding/scripts
-node create_bounty.js --config /path/to/bounty.json
+node create_bounty.js --config /path/to/bounty.json --yes
 ```
 
 The script will:
@@ -329,7 +358,7 @@ After the script completes, the bounty is OPEN and fully visible in the UI with 
 For quick on-chain smoke tests (no rubric, no title in UI):
 
 ```bash
-node scripts/create_bounty_min.js --eth 0.001 --hours 6 --classId 128
+node scripts/create_bounty_min.js --eth 0.001 --hours 6 --classId 128 --yes
 ```
 
 This uses a hardcoded evaluation CID and skips the API. Use **only** to verify the bot wallet can transact on-chain. Do **not** use for real bounties — the CID mismatch will cause sync issues.
@@ -351,18 +380,18 @@ curl -H "X-Bot-API-Key: YOUR_KEY" \
 curl -H "X-Bot-API-Key: YOUR_KEY" \
   "{VERDIKTA_BOUNTIES_BASE_URL}/api/jobs/{jobId}/rubric"
 
-# Estimate LINK cost
+# Estimate legacy LINK cost, if applicable
 curl -H "X-Bot-API-Key: YOUR_KEY" \
   "{VERDIKTA_BOUNTIES_BASE_URL}/api/jobs/{jobId}/estimate-fee"
 
-# Validate the bounty's evaluation package before committing LINK
+# Validate the bounty's evaluation package before committing funds
 curl -H "X-Bot-API-Key: YOUR_KEY" \
   "{VERDIKTA_BOUNTIES_BASE_URL}/api/jobs/{jobId}/validate"
 ```
 
 Read the rubric carefully. Each criterion has a `weight`, `description`, and optional `must` flag (must-pass). The `threshold` is the minimum score (0-100) needed to pass. Check `forbiddenContent` to avoid automatic failure.
 
-**Before submitting**, validate the bounty. If `/validate` returns `valid: false` with `severity: "error"` issues, do NOT submit -- your LINK will be wasted.
+**Before submitting**, validate the bounty. If `/validate` returns `valid: false` with `severity: "error"` issues, do NOT submit -- gas, oracle prepay, and any legacy LINK allowance can be wasted.
 
 ### Step 1.5 (recommended): Run pre-flight check
 
@@ -370,9 +399,10 @@ Run the pre-flight script to verify everything before spending funds:
 
 ```bash
 node preflight.js --jobId 72
+node preflight.js --jobId 72 --require-link    # legacy LINK-funded backend
 ```
 
-This checks: API job is OPEN, evaluation package is valid, on-chain bounty matches API, deadline has sufficient buffer, and the bot has enough LINK + ETH. Prints **GO** or **NO-GO**. See [Pre-flight check](#pre-flight-check-use-preflightjs) below for details.
+This checks: API job is OPEN, evaluation package is valid, on-chain bounty matches API, deadline has sufficient buffer, and the bot has enough ETH plus any backend-required LINK. Prints **GO** or **NO-GO**. See [Pre-flight check](#pre-flight-check-use-preflightjs) below for details.
 
 ### Step 2: Do the work
 
@@ -386,7 +416,7 @@ The `submit_to_bounty.js` script handles the **entire** submission flow in one c
 - Runs pre-flight checks (validates evaluation package, checks on-chain status)
 - Uploads files to IPFS
 - Signs and broadcasts on-chain `prepareSubmission` (deploys EvaluationWallet)
-- Signs and broadcasts on-chain LINK `approve` to the EvaluationWallet
+- Signs and broadcasts on-chain LINK `approve` only when the backend requires it
 - Signs and broadcasts on-chain `startPreparedSubmission` (triggers oracle evaluation)
 - Confirms the submission record in the API
 - Prints the submission ID and next steps
@@ -395,13 +425,13 @@ The `submit_to_bounty.js` script handles the **entire** submission flow in one c
 cd ~/.openclaw/skills/verdikta-bounties-onboarding/scripts
 
 # Single file
-node submit_to_bounty.js --jobId 72 --file /path/to/work_output.md
+node submit_to_bounty.js --jobId 72 --file /path/to/work_output.md --yes
 
 # Multiple files with narrative
-node submit_to_bounty.js --jobId 72 --file report.md --file appendix.md --narrative "Summary of work"
+node submit_to_bounty.js --jobId 72 --file report.md --file appendix.md --narrative "Summary of work" --yes
 
 # With custom fee parameters (advanced)
-node submit_to_bounty.js --jobId 72 --file work.md --alpha 50 --maxOracleFee 0.003
+node submit_to_bounty.js --jobId 72 --file work.md --alpha 50 --maxOracleFee 0.003 --yes
 ```
 
 The script uses the bot wallet (from `.env`) to sign all transactions. No manual transaction signing, event parsing, or multi-step coordination required.
@@ -418,11 +448,13 @@ The script uses the bot wallet (from `.env`) to sign all transactions. No manual
 | `--file <path>` | Required (at least one). Work product file(s). |
 | `--narrative "..."` | Optional. Summary text for evaluators. |
 | `--alpha <N>` | Optional. Reputation weight (default: API default, 50 = nominal). |
-| `--maxOracleFee <N>` | Optional. Max LINK per oracle call (default: API default, ~0.003). |
-| `--estimatedBaseCost <N>` | Optional. Base cost estimate in LINK. |
+| `--maxOracleFee <N>` | Optional. Legacy max LINK per oracle call when required by backend. |
+| `--estimatedBaseCost <N>` | Optional. Legacy base cost estimate in LINK. |
 | `--maxFeeBasedScaling <N>` | Optional. Fee scaling factor. |
 | `--confirm-first` | Force legacy ordering (confirm before start). |
 | `--skip-confirm` | Skip API confirm (trustless on-chain-only mode). |
+| `--dry-run` | Stop after pre-flight checks; upload nothing and sign nothing. |
+| `--yes` / `--confirm-spend` | Confirm spending/non-interactive signing after reviewing the command. |
 
 ### Step 4: Wait, then claim payout using claim_bounty.js (REQUIRED)
 
@@ -432,7 +464,7 @@ After `submit_to_bounty.js` completes, the submission enters `PENDING_EVALUATION
 
 ```bash
 cd ~/.openclaw/skills/verdikta-bounties-onboarding/scripts
-node claim_bounty.js --jobId 80 --submissionId 0
+node claim_bounty.js --jobId 80 --submissionId 0 --yes
 ```
 
 The script will:
@@ -464,9 +496,9 @@ If you need to run the steps individually (e.g., for debugging), the documented 
 
 1. **Validate**: `GET /api/jobs/{jobId}/validate` — abort if `valid: false` with errors
 2. **Upload files**: `POST /api/jobs/{jobId}/submit` → returns `hunterCid`
-3. **Prepare**: `POST /api/jobs/{jobId}/submit/prepare` with `{hunter, hunterCid}` (+ optional: `alpha`, `maxOracleFee`, `estimatedBaseCost`, `maxFeeBasedScaling`) → sign tx → parse `SubmissionPrepared` event for `submissionId`, `evalWallet`, `linkMaxBudget`
-4. **Approve LINK**: `POST /api/jobs/{jobId}/submit/approve` with `{evalWallet, linkAmount}` → sign tx. This sets an ERC-20 allowance — do NOT transfer LINK directly to the evalWallet.
-5. **Start**: `POST /api/jobs/{jobId}/submissions/{submissionId}/start` with `{hunter}` → sign tx. The contract pulls LINK via `transferFrom`.
+3. **Prepare**: `POST /api/jobs/{jobId}/submit/prepare` with `{hunter, hunterCid}` (+ optional: `alpha`, `maxOracleFee`, `estimatedBaseCost`, `maxFeeBasedScaling`) → review/allowlist-check/sign tx → parse `SubmissionPrepared` event for `submissionId`, `evalWallet`, and any budget fields.
+4. **Approve LINK when required by the backend**: `POST /api/jobs/{jobId}/submit/approve` with `{evalWallet, linkAmount}` → review/allowlist-check/sign tx. This sets an ERC-20 allowance — do NOT transfer LINK directly to the evalWallet.
+5. **Start**: `POST /api/jobs/{jobId}/submissions/{submissionId}/start` with `{hunter}` → review/allowlist-check/sign returned payable tx. Modern backends use the returned ETH `value` for the oracle prepay.
 6. **Confirm**: `POST /api/jobs/{jobId}/submissions/confirm` with `{submissionId, hunter, hunterCid}` — registers submission in API
 
 The documented order is **start then confirm** (steps 5→6). Some backend versions may require confirm before start. The `submit_to_bounty.js` script handles this automatically with fallback logic.
@@ -491,8 +523,8 @@ The script checks:
 3. On-chain bounty matches API (creator, CID, classId, threshold via `getBounty()`)
 4. On-chain `isAcceptingSubmissions()` returns true
 5. Deadline has sufficient buffer (default: 30 minutes)
-6. Bot has sufficient LINK balance (compared to `/estimate-fee`)
-7. Bot has sufficient ETH for gas (~3 transactions)
+6. Bot has sufficient ETH for gas and any returned payable oracle prepay
+7. Bot has sufficient LINK only when the active backend still requires LINK approval
 
 Prints **GO** (exit code 0) or **NO-GO** (exit code 1) with per-check details. Does not spend any funds.
 
@@ -519,10 +551,10 @@ All calldata API endpoints return a transaction object like:
 }
 ```
 
-To sign and broadcast using the bot wallet with `ethers.js`:
+To sign and broadcast an API-provided transaction, use the checked helper so the recipient, chain ID, calldata, and ETH value are validated before signing:
 
 ```javascript
-import { providerFor, loadWallet, getNetwork } from './_lib.js';
+import { providerFor, loadWallet, getNetwork, ESCROW, sendTx } from './_lib.js';
 
 const network = getNetwork();
 const provider = providerFor(network);
@@ -530,18 +562,15 @@ const wallet = await loadWallet();
 const signer = wallet.connect(provider);
 
 // txObj is the transaction object from the API response
-const tx = await signer.sendTransaction({
-  to: txObj.to,
-  data: txObj.data,
-  value: txObj.value || "0",
-  gasLimit: txObj.gasLimit || 500000,
+const receipt = await sendTx(signer, 'finalizeSubmission', txObj, {
+  expectedTo: ESCROW[network],
+  network,
 });
-const receipt = await tx.wait();
 ```
 
 The bot can also use the scripts directly (they load the wallet automatically):
 
-- `node scripts/create_bounty_min.js` — create a bounty on-chain
+- `node scripts/create_bounty_min.js --yes` — create a minimal bounty on-chain for smoke testing only
 - `node scripts/funding_check.js` — check ETH and LINK balances
 - `node scripts/bounty_worker_min.js` — list open bounties
 
@@ -562,9 +591,9 @@ Process transactions sequentially — wait for each confirmation before the next
 ## External endpoints (network transparency)
 
 > WHAT IS READ: VERDIKTA_WALLET_PASSWORD, VERDIKTA_KEYSTORE_PATH from ~/.config/verdikta-bounties/.env; API key from ~/.config/verdikta-bounties/verdikta-bounties-bot.json.
-> WHAT IS TRANSMITTED: Signed transactions to Base RPC; API key + bounty data to VERDIKTA_BOUNTIES_BASE_URL; optional swap params to api.0x.org (mainnet only).
+> WHAT IS TRANSMITTED: Signed transactions to Base RPC; API key + bounty data + submitted work files to VERDIKTA_BOUNTIES_BASE_URL; optional swap params to api.0x.org (mainnet only).
 > WHAT IS LOGGED: Transaction hashes, block numbers, job/bounty IDs, wallet address. No secrets, no private keys, no API keys in logs (keys redacted).
-> AUTONOMOUS START: never. All scripts run only when explicitly invoked by the user/agent.
+> AUTONOMOUS START: never. All scripts run only when explicitly invoked by the user/agent, and transaction-capable scripts require an interactive review or `--yes` / `--confirm-spend`.
 
 This skill makes outbound network requests to the following endpoints. No other hosts are contacted.
 
@@ -621,7 +650,7 @@ No data is sent to any other third party. The skill does not invoke AI models di
 | `wallet_init.js` | Create or import (`--import`) encrypted wallet keystore |
 | `funding_check.js` | Check ETH and LINK balances |
 | `funding_instructions.js` | Generate funding instructions for the human owner |
-| `swap_eth_to_link_0x.js` | Swap ETH to LINK via 0x API (mainnet only) |
+| `swap_eth_to_link_0x.js` | Optional/deprecated ETH to LINK swap via 0x API (mainnet only; explicit spend confirmation required) |
 
 ## Environment variables reference
 

--- a/skills/verdikta-bounties-onboarding/_meta.json
+++ b/skills/verdikta-bounties-onboarding/_meta.json
@@ -1,7 +1,59 @@
 {
   "ownerId": "kn70kt901qt3bjzwb1v3q90jm181xhyf",
   "slug": "verdikta-bounties-onboarding",
-  "version": "1.4.1",
+  "version": "1.4.2",
+  "description": "Hot-wallet Verdikta Bounties operator for Base. Creates/imports Ethereum keys, stores encrypted keystore and API key locally, uploads public bounty/work data, calls Verdikta API/Base RPC/optional 0x, and can sign irreversible mainnet/testnet transactions.",
+  "permissions": {
+    "shell": {
+      "binaries": ["node", "npm"],
+      "purpose": "Run local helper scripts and install JavaScript dependencies."
+    },
+    "network": {
+      "required": [
+        "https://bounties.verdikta.org",
+        "https://bounties-testnet.verdikta.org",
+        "https://mainnet.base.org",
+        "https://sepolia.base.org"
+      ],
+      "optional": [
+        "https://api.0x.org"
+      ],
+      "notes": "Configured Base RPC URLs and Verdikta API URL are read from the skill config; custom endpoints should be reviewed before signing."
+    },
+    "filesystem": {
+      "read": [
+        "~/.config/verdikta-bounties/.env",
+        "~/.config/verdikta-bounties/verdikta-bounties-bot.json",
+        "~/.config/verdikta-bounties/verdikta-wallet.json",
+        "scripts/.env",
+        "scripts/*.json",
+        "operator-selected work files for submission"
+      ],
+      "write": [
+        "~/.config/verdikta-bounties/.env",
+        "~/.config/verdikta-bounties/verdikta-bounties-bot.json",
+        "~/.config/verdikta-bounties/verdikta-wallet.json"
+      ],
+      "notes": "scripts/.env is a legacy/dev fallback. The stable config path is preferred for production."
+    },
+    "cryptoWallet": {
+      "hotWalletSigning": true,
+      "walletCreation": true,
+      "privateKeyImport": true,
+      "chains": [
+        { "name": "base", "chainId": 8453 },
+        { "name": "base-sepolia", "chainId": 84532 }
+      ],
+      "transactionTypes": [
+        "create/fund bounty",
+        "submit work",
+        "approve LINK when required",
+        "start evaluation with payable ETH prepay",
+        "finalize or claim payout",
+        "optional ETH-to-LINK swap"
+      ]
+    }
+  },
   "requiredEnvVars": [
     "VERDIKTA_WALLET_PASSWORD",
     "VERDIKTA_NETWORK",
@@ -35,12 +87,18 @@
       "OFFBOT_ADDRESS"
     ],
     "sensitive": true,
-    "notes": "Credentials read fresh from disk at runtime — never embedded as literals. VERDIKTA_WALLET_PASSWORD decrypts the keystore in-memory only when signing transactions; private keys are never written to disk or logs. API key stored separately at ~/.config/verdikta-bounties/verdikta-bounties-bot.json (chmod 600). All files permission-restricted (0o600). Grant wallet minimal funds only — hot wallet posture."
+    "notes": "Credentials read fresh from disk at runtime — never embedded as literals. VERDIKTA_WALLET_PASSWORD decrypts the keystore in-memory only when signing transactions; private keys are never written to disk or logs. API key stored separately at ~/.config/verdikta-bounties/verdikta-bounties-bot.json (chmod 600). Scripts enforce chmod 600 after credential writes. Grant wallet minimal funds only — hot wallet posture."
   },
   "credentialSetup": {
     "type": "interactive",
-    "description": "Run 'node scripts/onboard.js' for guided setup: creates encrypted wallet keystore, waits for human funding, registers bot API key. No secrets are hardcoded."
+    "description": "Run 'node scripts/onboard.js' for guided setup: creates or imports an encrypted wallet keystore, waits for human funding, registers and persists a bot API key. No secrets are hardcoded."
   },
+  "securityNotes": [
+    "Use a fresh low-balance bot wallet; do not import high-value personal wallets.",
+    "Transaction-capable scripts require interactive confirmation or --yes/--confirm-spend.",
+    "Use --dry-run where available before signing.",
+    "Bounty metadata, submitted work files, CIDs, wallet addresses, and transaction hashes may become public via IPFS, Verdikta API records, and blockchain state."
+  ],
   "requires": {
     "anyBinaries": ["node", "npm"],
     "os": ["windows", "macos", "linux"]

--- a/skills/verdikta-bounties-onboarding/publish.sh
+++ b/skills/verdikta-bounties-onboarding/publish.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
 STAGE_DIR="${SKILL_DIR}/.clawhub-stage"
-VERSION="${VERSION:-1.4.1}"
+VERSION="${VERSION:-1.4.2}"
 DRY_RUN=""
 
 if [[ "${1:-}" == "--dry-run" ]]; then

--- a/skills/verdikta-bounties-onboarding/references/security.md
+++ b/skills/verdikta-bounties-onboarding/references/security.md
@@ -1,10 +1,12 @@
 # Security notes (bot wallet)
 
 ## Hot-wallet reality
-This bot wallet is a hot wallet. Assume compromise is possible.
+This bot wallet is a hot wallet. Assume compromise is possible. Transactions on Base mainnet and Base Sepolia are irreversible once confirmed, and mistakes can spend gas, lock funds, or publish unwanted metadata.
 
 Recommended practices:
 - Keep balances low.
+- Start on Base Sepolia and use a fresh bot-only wallet.
+- Do not import high-value personal wallets.
 - Use a sweep rule (e.g., send excess to cold address daily / when above threshold).
 - Store the keystore file with `chmod 600` and outside web roots.
 
@@ -21,18 +23,37 @@ This skill uses an **encrypted JSON keystore** (ethers-compatible).
 - It does **not** read `.env` from the caller's working directory (CWD).
 - This prevents accidental exposure of unrelated secrets if scripts are run from other directories.
 - `dotenv` does not overwrite already-set variables, so the stable path values take priority.
+- Treat `scripts/.env` as legacy/dev scope. Production operators should migrate to `~/.config/verdikta-bounties/.env` and avoid leaving developer-only endpoint overrides in the skill directory.
 
 ## API key handling
 - The API key is stored locally at `~/.config/verdikta-bounties/verdikta-bounties-bot.json` with `chmod 600`.
 - Console output redacts API keys (shows only first 4 + last 4 characters).
 - The API key is sent only to the configured `VERDIKTA_BOUNTIES_BASE_URL` as an `X-Bot-API-Key` header.
+- The bot registration response can contain the API key and is persisted as durable local credential material. Keep the file out of backups/log captures unless you intend to preserve the credential.
+
+## Network and transaction allowlists
+Expected external destinations:
+
+- Verdikta Agent API: `https://bounties.verdikta.org` or `https://bounties-testnet.verdikta.org`
+- Base RPC: `https://mainnet.base.org` or `https://sepolia.base.org`, unless explicitly overridden in config
+- Optional 0x swap API: `https://api.0x.org` on mainnet only
+
+Transaction-capable scripts check:
+
+- RPC/provider chain ID is Base `8453` or Base Sepolia `84532`, matching `VERDIKTA_NETWORK`
+- API-provided submission/finalization transactions target the expected escrow contract
+- API-provided LINK approval transactions target the configured LINK token
+- Nonzero ETH value is rejected except for operations where ETH is expected
+
+Use `--dry-run` where available, then `--yes` or `--confirm-spend` only after reviewing the printed action summary.
 
 ## Approvals / swap risk
 Swapping ETH→LINK requires signing a transaction with calldata provided by a DEX aggregator.
 
 Mitigations:
+- Prefer not to swap unless the active backend requires LINK.
 - Only use known endpoints (0x API) and correct chainId.
 - Set strict slippage.
 - Limit swap size.
-- Consider allowlisting token addresses.
-
+- Validate token addresses, transaction value, and quote recipient before signing.
+- Custom 0x endpoints require explicit `--allow-custom-0x`.

--- a/skills/verdikta-bounties-onboarding/scripts/_lib.js
+++ b/skills/verdikta-bounties-onboarding/scripts/_lib.js
@@ -20,8 +20,8 @@ export const ERC20_ABI = [
 // ---- BountyEscrow contract addresses (canonical, from Blockchain docs) ----
 
 export const ESCROW = {
-  'base': process.env.BOUNTY_ESCROW_ADDRESS_BASE || '0x3970dC3750DdE4E73fdcd3a81b66F1472BbaAEee',
-  'base-sepolia': process.env.BOUNTY_ESCROW_ADDRESS_BASE_SEPOLIA || '0x0520b15Ee61C4E2A1B00bA260d8B1FBD015D2780',
+  'base': process.env.BOUNTY_ESCROW_ADDRESS_BASE || '0x2ae271f5e86bee449a36b943414b7c1a7b39772d',
+  'base-sepolia': process.env.BOUNTY_ESCROW_ADDRESS_BASE_SEPOLIA || '0xAA67686Bb09F569C2C3b663BB3679dD9f9F60BDC',
 };
 
 // ---- BountyEscrow ABI (subset needed by scripts) ----

--- a/skills/verdikta-bounties-onboarding/scripts/_lib.js
+++ b/skills/verdikta-bounties-onboarding/scripts/_lib.js
@@ -1,8 +1,9 @@
 import './_env.js';
+import readline from 'node:readline/promises';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { JsonRpcProvider, Wallet, Contract, parseEther } from 'ethers';
+import { JsonRpcProvider, Wallet, Contract, parseEther, formatEther } from 'ethers';
 import { defaultSecretsDir } from './_paths.js';
 
 export const LINK = {
@@ -22,6 +23,11 @@ export const ERC20_ABI = [
 export const ESCROW = {
   'base': process.env.BOUNTY_ESCROW_ADDRESS_BASE || '0x2ae271f5e86bee449a36b943414b7c1a7b39772d',
   'base-sepolia': process.env.BOUNTY_ESCROW_ADDRESS_BASE_SEPOLIA || '0xAA67686Bb09F569C2C3b663BB3679dD9f9F60BDC',
+};
+
+export const CHAIN_IDS = {
+  base: 8453,
+  'base-sepolia': 84532,
 };
 
 // ---- BountyEscrow ABI (subset needed by scripts) ----
@@ -73,6 +79,12 @@ export function redactApiKey(key) {
 
 export function getNetwork() {
   return process.env.VERDIKTA_NETWORK || 'base';
+}
+
+export function expectedChainId(network = getNetwork()) {
+  const id = CHAIN_IDS[network];
+  if (!id) throw new Error(`Unsupported VERDIKTA_NETWORK: ${network}`);
+  return id;
 }
 
 export function getRpcUrl(network) {
@@ -152,6 +164,39 @@ export async function loadApiKey() {
   return j.apiKey || j.api_key || j.bot?.apiKey || j.bot?.api_key;
 }
 
+// ---- Spending confirmation helpers ----
+
+export function hasSpendConfirmationFlag() {
+  return hasFlag('yes') || hasFlag('confirm-spend');
+}
+
+export async function confirmSpendOrExit(summary, { requiredText = 'YES' } = {}) {
+  if (hasSpendConfirmationFlag()) return;
+
+  console.log('\nSPEND REVIEW');
+  for (const line of summary) console.log(`  ${line}`);
+
+  if (!process.stdin.isTTY) {
+    console.error(`\nRefusing to continue without explicit spend authorization. Re-run with --yes or --confirm-spend after reviewing the operation.`);
+    process.exit(1);
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`Type ${requiredText} to sign/broadcast transactions: `)).trim();
+    if (answer !== requiredText) {
+      console.error('Spend not confirmed. Aborting before signing.');
+      process.exit(1);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+export function isDryRun() {
+  return hasFlag('dry-run') || hasFlag('dryRun');
+}
+
 // ---- Class models (supported jury nodes) ----
 
 export function normalizeProvider(p) {
@@ -217,13 +262,76 @@ export function validateAndNormalizeJuryNodes({ classId, juryNodes, supported })
  * @param {object} [opts]
  * @param {boolean} [opts.useApiGasLimit] - Use the gasLimit from txObj instead of estimating
  */
-export async function sendTx(signer, label, txObj, { useApiGasLimit = false } = {}) {
+function normalizeTxValue(v) {
+  if (v == null || v === '') return 0n;
+  return BigInt(v);
+}
+
+function requireHexData(data, label) {
+  if (data == null) return;
+  if (typeof data !== 'string' || !/^0x([0-9a-fA-F]{2})*$/.test(data)) {
+    throw new Error(`${label} transaction has invalid calldata`);
+  }
+}
+
+function sameAddress(a, b) {
+  return String(a || '').toLowerCase() === String(b || '').toLowerCase();
+}
+
+/**
+ * Sign and broadcast a transaction, with recipient, chain, value, and calldata checks.
+ * Exits the process on revert to prevent wasted gas.
+ * @param {import('ethers').Signer} signer
+ * @param {string} label - Human-readable label for logging
+ * @param {object} txObj - Transaction object from API ({ to, data, value, gasLimit?, chainId? })
+ * @param {object} [opts]
+ * @param {boolean} [opts.useApiGasLimit] - Use the gasLimit from txObj instead of estimating
+ * @param {string} [opts.network] - Expected Verdikta network
+ * @param {string} [opts.expectedTo] - Required transaction recipient
+ * @param {boolean} [opts.allowValue] - Allow nonzero ETH value
+ * @param {bigint|string|number} [opts.maxValueWei] - Maximum allowed ETH value
+ */
+export async function sendTx(
+  signer,
+  label,
+  txObj,
+  { useApiGasLimit = false, network = getNetwork(), expectedTo = null, allowValue = false, maxValueWei = null } = {}
+) {
   console.log(`\n→ ${label}: sending transaction...`);
+
+  if (!txObj || typeof txObj !== 'object') {
+    throw new Error(`${label} transaction missing`);
+  }
+  if (!txObj.to) {
+    throw new Error(`${label} transaction missing recipient`);
+  }
+
+  const chainId = expectedChainId(network);
+  if (txObj.chainId != null && Number(txObj.chainId) !== chainId) {
+    throw new Error(`${label} transaction chainId mismatch: got ${txObj.chainId}, expected ${chainId} (${network})`);
+  }
+  if (expectedTo && !sameAddress(txObj.to, expectedTo)) {
+    throw new Error(`${label} transaction recipient mismatch: got ${txObj.to}, expected ${expectedTo}`);
+  }
+
+  requireHexData(txObj.data, label);
+  const valueWei = normalizeTxValue(txObj.value);
+  if (!allowValue && valueWei !== 0n) {
+    throw new Error(`${label} transaction unexpectedly includes ETH value ${formatEther(valueWei)} ETH`);
+  }
+  if (maxValueWei != null && valueWei > BigInt(maxValueWei)) {
+    throw new Error(`${label} transaction value ${formatEther(valueWei)} ETH exceeds limit ${formatEther(BigInt(maxValueWei))} ETH`);
+  }
+
   const baseTx = {
     to: txObj.to,
     data: txObj.data,
-    value: txObj.value || '0',
+    value: valueWei,
   };
+
+  console.log(`  chainId: ${chainId} (${network})`);
+  console.log(`  to:      ${baseTx.to}`);
+  console.log(`  value:   ${formatEther(valueWei)} ETH`);
 
   let gasLimit;
 

--- a/skills/verdikta-bounties-onboarding/scripts/bot_register.js
+++ b/skills/verdikta-bounties-onboarding/scripts/bot_register.js
@@ -31,6 +31,7 @@ if (!resp.ok) {
 
 await ensureDir(path.dirname(outPath));
 await fs.writeFile(outPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+await fs.chmod(outPath, 0o600);
 
 const key = data?.apiKey || data?.api_key || data?.bot?.apiKey || data?.bot?.api_key;
 console.log('Registered bot. Saved response to:', outPath);

--- a/skills/verdikta-bounties-onboarding/scripts/claim_bounty.js
+++ b/skills/verdikta-bounties-onboarding/scripts/claim_bounty.js
@@ -3,8 +3,8 @@
 // The bot wallet signs the finalizeSubmission transaction automatically.
 //
 // Usage:
-//   node claim_bounty.js --jobId 80 --submissionId 0
-//   node claim_bounty.js --jobId 80 --submissionId 0 --maxWait 600
+//   node claim_bounty.js --jobId 80 --submissionId 0 --yes
+//   node claim_bounty.js --jobId 80 --submissionId 0 --maxWait 600 --dry-run
 //
 // Typical flow:
 //   1. Run submit_to_bounty.js → submission enters PENDING_EVALUATION
@@ -17,8 +17,8 @@
 
 import './_env.js';
 import {
-  getNetwork, providerFor, loadWallet, redactApiKey,
-  arg, loadApiKey, sendTx,
+  getNetwork, providerFor, loadWallet, redactApiKey, ESCROW,
+  arg, loadApiKey, sendTx, confirmSpendOrExit, isDryRun,
 } from './_lib.js';
 
 const jobId = arg('jobId');
@@ -137,6 +137,23 @@ while (true) {
 
 console.log('\n--- Step 2: Finalize submission (claim payout) ---');
 
+if (isDryRun()) {
+  console.log('Dry run complete: evaluation is ready for finalization.');
+  console.log('No finalize transaction was requested or signed.');
+  process.exit(0);
+}
+
+await confirmSpendOrExit([
+  `Action: finalize Verdikta submission and claim/refund on-chain funds`,
+  `Network: ${network}`,
+  `Hunter wallet: ${hunter}`,
+  `API: ${baseUrl}`,
+  `Job: #${jobId}`,
+  `Submission: #${submissionId}`,
+  `Allowed escrow recipient: ${ESCROW[network]}`,
+  `Current status: ${status}`,
+]);
+
 const finalizeRes = await fetch(
   `${baseUrl}/api/jobs/${jobId}/submissions/${submissionId}/finalize`,
   {
@@ -182,7 +199,10 @@ if (finalizeData.expectedPayout) {
   console.log(`  Expected payout: ${finalizeData.expectedPayout} ETH`);
 }
 
-const finalizeReceipt = await sendTx(signer, 'finalizeSubmission', finalizeData.transaction);
+const finalizeReceipt = await sendTx(signer, 'finalizeSubmission', finalizeData.transaction, {
+  expectedTo: ESCROW[network],
+  network,
+});
 
 // ---- Done ----
 

--- a/skills/verdikta-bounties-onboarding/scripts/create_bounty.js
+++ b/skills/verdikta-bounties-onboarding/scripts/create_bounty.js
@@ -224,6 +224,15 @@ if (!contractAddress) {
   process.exit(1);
 }
 
+const apiContractAddress = apiData.job?.contractAddress;
+if (apiContractAddress && apiContractAddress.toLowerCase() !== contractAddress.toLowerCase()) {
+  console.error('Escrow contract mismatch; refusing to spend gas.');
+  console.error(`  Script escrow: ${contractAddress}`);
+  console.error(`  API expects:   ${apiContractAddress}`);
+  console.error('Update BOUNTY_ESCROW_ADDRESS_BASE or scripts/_lib.js, then retry.');
+  process.exit(1);
+}
+
 const contract = escrowContract(network, signer);
 const deadline = Math.floor(Date.now() / 1000) + (Number(submissionWindowHours) * 3600);
 const value = ethers.parseEther(String(bountyAmount));

--- a/skills/verdikta-bounties-onboarding/scripts/create_bounty.js
+++ b/skills/verdikta-bounties-onboarding/scripts/create_bounty.js
@@ -3,7 +3,8 @@
 // The bot wallet signs the on-chain transaction automatically.
 //
 // Usage:
-//   node create_bounty.js --config bounty.json
+//   node create_bounty.js --config bounty.json --yes
+//   node create_bounty.js --config bounty.json --dry-run
 //
 // bounty.json example:
 // {
@@ -41,6 +42,7 @@ import {
   getNetwork, providerFor, loadWallet,
   ESCROW, escrowContract, arg, loadApiKey,
   getSupportedModelsForClass, validateAndNormalizeJuryNodes,
+  confirmSpendOrExit, isDryRun, expectedChainId,
 } from './_lib.js';
 
 const configPath = arg('config');
@@ -137,6 +139,11 @@ if (!baseUrl) {
 }
 
 const provider = providerFor(network);
+const providerNetwork = await provider.getNetwork();
+if (Number(providerNetwork.chainId) !== expectedChainId(network)) {
+  console.error(`RPC chainId mismatch: got ${providerNetwork.chainId}, expected ${expectedChainId(network)} for ${network}. Refusing to spend gas.`);
+  process.exit(1);
+}
 const wallet = await loadWallet();
 const signer = wallet.connect(provider);
 const creator = signer.address;
@@ -168,6 +175,23 @@ console.log(`Class:    ${classId}`);
 console.log(`Window:   ${submissionWindowHours}h`);
 console.log(`Jury:     ${juryNodes.map(n => `${n.provider}/${n.model}`).join(', ')}`);
 console.log(`API:      ${baseUrl}`);
+
+if (isDryRun()) {
+  console.log('\nDry run complete: config, wallet, API key, and jury model checks passed.');
+  console.log('No API job was created and no transaction was signed.');
+  process.exit(0);
+}
+
+await confirmSpendOrExit([
+  `Action: create Verdikta bounty and fund it on-chain`,
+  `Network: ${network}`,
+  `Creator wallet: ${creator}`,
+  `API: ${baseUrl}`,
+  `Escrow: ${ESCROW[network] || '(unknown)'}`,
+  `Bounty amount: ${bountyAmount} ETH plus gas`,
+  `Title: ${title}`,
+  `Public data: bounty metadata and evaluation package may be pinned to IPFS and written on-chain`,
+]);
 
 // ---- Step 1: Create job via API ----
 
@@ -237,6 +261,17 @@ const contract = escrowContract(network, signer);
 const deadline = Math.floor(Date.now() / 1000) + (Number(submissionWindowHours) * 3600);
 const value = ethers.parseEther(String(bountyAmount));
 
+function parseOptionalGweiEnv(name) {
+  const raw = process.env[name];
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(`${name} must be a positive number of gwei when set.`);
+    process.exit(1);
+  }
+  return ethers.parseUnits(String(raw), 'gwei');
+}
+
 console.log(`  Escrow:    ${contractAddress}`);
 console.log(`  CID:       ${primaryCid}`);
 console.log(`  Deadline:  ${new Date(deadline * 1000).toISOString()}`);
@@ -245,9 +280,10 @@ console.log(`  Deadline:  ${new Date(deadline * 1000).toISOString()}`);
 const targetHunter = ethers.ZeroAddress;
 
 // Dry-run first to catch revert reasons before spending gas
+let estimatedGas;
 try {
-  const gas = await contract.createBounty.estimateGas(primaryCid, classId, threshold, deadline, targetHunter, { value });
-  console.log(`  estimated gas: ${gas.toString()}`);
+  estimatedGas = await contract.createBounty.estimateGas(primaryCid, classId, threshold, deadline, targetHunter, { value });
+  console.log(`  estimated gas: ${estimatedGas.toString()}`);
 } catch (err) {
   const reason = err.reason || err.shortMessage || err.message || 'unknown';
   console.error(`\n✖ createBounty will revert! Reason: ${reason}`);
@@ -255,7 +291,25 @@ try {
   process.exit(1);
 }
 
-const tx = await contract.createBounty(primaryCid, classId, threshold, deadline, targetHunter, { value });
+const txOptions = {
+  value,
+  gasLimit: (estimatedGas * 120n) / 100n,
+};
+const maxFeePerGas = parseOptionalGweiEnv('VERDIKTA_CREATE_MAX_FEE_GWEI');
+const maxPriorityFeePerGas = parseOptionalGweiEnv('VERDIKTA_CREATE_MAX_PRIORITY_FEE_GWEI');
+if (maxFeePerGas != null || maxPriorityFeePerGas != null) {
+  if (maxFeePerGas == null || maxPriorityFeePerGas == null) {
+    console.error('Set both VERDIKTA_CREATE_MAX_FEE_GWEI and VERDIKTA_CREATE_MAX_PRIORITY_FEE_GWEI, or neither.');
+    process.exit(1);
+  }
+  txOptions.maxFeePerGas = maxFeePerGas;
+  txOptions.maxPriorityFeePerGas = maxPriorityFeePerGas;
+  console.log(`  maxFeePerGas override: ${ethers.formatUnits(maxFeePerGas, 'gwei')} gwei`);
+  console.log(`  maxPriorityFeePerGas override: ${ethers.formatUnits(maxPriorityFeePerGas, 'gwei')} gwei`);
+}
+console.log(`  gasLimit: ${txOptions.gasLimit.toString()}`);
+
+const tx = await contract.createBounty(primaryCid, classId, threshold, deadline, targetHunter, txOptions);
 console.log(`  tx: ${tx.hash}`);
 const receipt = await tx.wait();
 

--- a/skills/verdikta-bounties-onboarding/scripts/create_bounty_min.js
+++ b/skills/verdikta-bounties-onboarding/scripts/create_bounty_min.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import './_env.js';
 import { ethers } from 'ethers';
-import { getNetwork, providerFor, loadWallet, parseEth, arg, loadApiKey, ESCROW } from './_lib.js';
+import {
+  getNetwork, providerFor, loadWallet, parseEth, arg, loadApiKey, ESCROW,
+  confirmSpendOrExit, isDryRun, expectedChainId,
+} from './_lib.js';
 
 // Minimal on-chain bounty creation (no IPFS upload).
 // Intended for testnet smoke tests only.
@@ -13,6 +16,10 @@ import { getNetwork, providerFor, loadWallet, parseEth, arg, loadApiKey, ESCROW 
 
 const network = getNetwork();
 const provider = providerFor(network);
+const providerNetwork = await provider.getNetwork();
+if (Number(providerNetwork.chainId) !== expectedChainId(network)) {
+  throw new Error(`RPC chainId mismatch: got ${providerNetwork.chainId}, expected ${expectedChainId(network)} for ${network}`);
+}
 const wallet = await loadWallet();
 const signer = wallet.connect(provider);
 
@@ -99,6 +106,21 @@ console.log('classId:', classId);
 console.log('threshold:', threshold);
 console.log('deadline:', deadline, `(in ${hours}h)`);
 console.log('value:', amountEth, 'ETH');
+
+if (isDryRun()) {
+  console.log('Dry run complete: smoke-test transaction was not signed.');
+  process.exit(0);
+}
+
+await confirmSpendOrExit([
+  `Action: create a minimal on-chain smoke-test bounty`,
+  `Network: ${network}`,
+  `Creator wallet: ${signer.address}`,
+  `Escrow: ${contractAddress}`,
+  `Value: ${amountEth} ETH plus gas`,
+  `CID: ${evaluationCid}`,
+  `Warning: this does not create a full API-backed/evaluable bounty`,
+]);
 
 const tx = await contract.createBounty(evaluationCid, classId, threshold, deadline, { value });
 console.log('Tx:', tx.hash);

--- a/skills/verdikta-bounties-onboarding/scripts/onboard.js
+++ b/skills/verdikta-bounties-onboarding/scripts/onboard.js
@@ -46,10 +46,12 @@ async function loadOrInitEnvFile(envPath) {
   if (await fileExists(examplePath)) {
     const ex = await fs.readFile(examplePath, 'utf8');
     await fs.writeFile(envPath, ex, { mode: 0o600 });
+    await fs.chmod(envPath, 0o600);
     return;
   }
   // Minimal fallback
   await fs.writeFile(envPath, '', { mode: 0o600 });
+  await fs.chmod(envPath, 0o600);
 }
 
 function parseEnv(text) {
@@ -117,6 +119,7 @@ async function ensureWalletKeystore({ keystorePath, password, rl }) {
         // Re-encrypt with the current config password so everything stays consistent
         const reEncrypted = await wallet.encrypt(password);
         await fs.writeFile(abs, reEncrypted, { mode: 0o600 });
+        await fs.chmod(abs, 0o600);
         console.log('  Keystore re-encrypted with current password.');
         return { wallet, abs, created: false, imported: false };
       }
@@ -127,6 +130,7 @@ async function ensureWalletKeystore({ keystorePath, password, rl }) {
         const wallet = new Wallet(key.startsWith('0x') ? key : `0x${key}`);
         const json = await wallet.encrypt(password);
         await fs.writeFile(abs, json, { mode: 0o600 });
+        await fs.chmod(abs, 0o600);
         console.log('  Imported and encrypted. Old keystore overwritten.');
         return { wallet, abs, created: true, imported: true };
       }
@@ -152,6 +156,7 @@ async function ensureWalletKeystore({ keystorePath, password, rl }) {
       const wallet = new Wallet(key.startsWith('0x') ? key : `0x${key}`);
       const json = await wallet.encrypt(password);
       await fs.writeFile(abs, json, { mode: 0o600 });
+      await fs.chmod(abs, 0o600);
       console.log('  Imported and encrypted to keystore. Raw key was NOT saved.');
       return { wallet, abs, created: true, imported: true };
     }
@@ -166,6 +171,7 @@ async function ensureWalletKeystore({ keystorePath, password, rl }) {
       // Re-encrypt with the skill's password so all scripts use a consistent credential
       const reEncrypted = await wallet.encrypt(password);
       await fs.writeFile(abs, reEncrypted, { mode: 0o600 });
+      await fs.chmod(abs, 0o600);
       console.log('  Imported and re-encrypted to skill keystore.');
       return { wallet, abs, created: true, imported: true };
     }
@@ -174,6 +180,7 @@ async function ensureWalletKeystore({ keystorePath, password, rl }) {
   const wallet = Wallet.createRandom();
   const json = await wallet.encrypt(password);
   await fs.writeFile(abs, json, { mode: 0o600 });
+  await fs.chmod(abs, 0o600);
   return { wallet, abs, created: true, imported: false };
 }
 
@@ -327,6 +334,7 @@ async function main() {
       OFFBOT_ADDRESS: sweepAddress,
     });
     await fs.writeFile(envPath, patched, { mode: 0o600 });
+    await fs.chmod(envPath, 0o600);
 
     console.log(`\nSaved config: ${envPath} (survives skill updates)`);
     console.log('Secrets dir:', secretsDir);
@@ -418,6 +426,7 @@ async function main() {
       const reg = await registerBot({ baseUrl, name: botName, ownerAddress, description: botDescription });
       apiKey = reg.apiKey;
       await fs.writeFile(botOut, JSON.stringify(reg.data, null, 2), { mode: 0o600 });
+      await fs.chmod(botOut, 0o600);
 
       console.log(`\n✅ Registered bot. Saved: ${botOut}`);
       console.log('API key: saved to file (not reprinted here).');

--- a/skills/verdikta-bounties-onboarding/scripts/package.json
+++ b/skills/verdikta-bounties-onboarding/scripts/package.json
@@ -2,6 +2,10 @@
   "name": "verdikta-bounties-onboarding-scripts",
   "private": true,
   "type": "module",
+  "scripts": {
+    "check": "for f in *.js; do node --check \"$f\"; done && node validate_contract_config.js",
+    "validate:contracts": "node validate_contract_config.js"
+  },
   "dependencies": {
     "dotenv": "^16.4.5",
     "ethers": "^6.15.0"

--- a/skills/verdikta-bounties-onboarding/scripts/preflight.js
+++ b/skills/verdikta-bounties-onboarding/scripts/preflight.js
@@ -12,8 +12,8 @@
 //   3. On-chain bounty matches API (creator, CID, classId, threshold)
 //   4. On-chain isAcceptingSubmissions returns true
 //   5. Deadline has sufficient buffer
-//   6. Bot has sufficient LINK balance (via /estimate-fee)
-//   7. Bot has sufficient ETH for gas
+//   6. Bot has sufficient ETH for gas
+//   7. Bot has sufficient LINK only when /estimate-fee reports a positive LINK requirement
 //
 // Prints a clear GO / NO-GO verdict.
 
@@ -21,11 +21,12 @@ import './_env.js';
 import { ethers } from 'ethers';
 import {
   getNetwork, providerFor, loadWallet,
-  escrowContract, linkBalance, arg, loadApiKey,
+  escrowContract, linkBalance, arg, hasFlag, loadApiKey,
 } from './_lib.js';
 
 const jobId = arg('jobId');
 const minBufferMin = Number(arg('minBuffer', '30')); // minutes before deadline
+const requireLink = hasFlag('require-link');
 
 if (!jobId) {
   console.error('Usage: node preflight.js --jobId <ID> [--minBuffer <minutes>]');
@@ -179,27 +180,33 @@ if (job?.submissionCloseTime) {
   check('Deadline buffer', true, 'no deadline set');
 }
 
-// 6. LINK balance (vs estimate-fee)
-let estimatedLink = 0.05; // fallback
+// 6. LINK balance, only when the active backend reports a LINK requirement.
+let estimatedLink = null;
 try {
   const feeRes = await fetch(`${baseUrl}/api/jobs/${jobId}/estimate-fee`, { headers });
   if (feeRes.ok) {
     const feeData = await feeRes.json();
-    estimatedLink = Number(feeData.estimatedFee || feeData.fee || feeData.linkCost || 0.05);
+    estimatedLink = Number(feeData.estimatedFee || feeData.fee || feeData.linkCost || 0);
   }
 } catch { /* use fallback */ }
 
-try {
-  const { bal, dec } = await linkBalance(network, provider, botAddress);
-  const linkHuman = Number(ethers.formatUnits(bal, dec));
-  const enough = linkHuman >= estimatedLink;
-  check('LINK balance', enough,
-    enough
-      ? `${linkHuman.toFixed(4)} LINK (need ~${estimatedLink.toFixed(4)})`
-      : `${linkHuman.toFixed(4)} LINK — need ~${estimatedLink.toFixed(4)} LINK`
-  );
-} catch (err) {
-  check('LINK balance', false, err.message);
+if (requireLink && !(estimatedLink > 0)) estimatedLink = 0.05;
+
+if (estimatedLink > 0) {
+  try {
+    const { bal, dec } = await linkBalance(network, provider, botAddress);
+    const linkHuman = Number(ethers.formatUnits(bal, dec));
+    const enough = linkHuman >= estimatedLink;
+    check('LINK balance', enough,
+      enough
+        ? `${linkHuman.toFixed(4)} LINK (need ~${estimatedLink.toFixed(4)})`
+        : `${linkHuman.toFixed(4)} LINK — need ~${estimatedLink.toFixed(4)} LINK`
+    );
+  } catch (err) {
+    check('LINK balance', false, err.message);
+  }
+} else {
+  check('LINK balance', true, 'not required by active fee endpoint');
 }
 
 // 7. ETH balance for gas

--- a/skills/verdikta-bounties-onboarding/scripts/submit_to_bounty.js
+++ b/skills/verdikta-bounties-onboarding/scripts/submit_to_bounty.js
@@ -15,6 +15,8 @@
 // Flags:
 //   --skip-confirm         Skip the API /confirm call (trustless on-chain-only mode)
 //   --confirm-first        Use old ordering: confirm before start (fallback compatibility)
+//   --dry-run              Stop after pre-flight checks; upload nothing and sign nothing
+//   --yes                  Confirm spending/non-interactive signing
 //
 // Prerequisites:
 //   - Bot onboarded (onboard.js completed)
@@ -27,8 +29,8 @@ import path from 'node:path';
 import { ethers } from 'ethers';
 import {
   getNetwork, providerFor, loadWallet,
-  escrowContract, redactApiKey, BOUNTY_ESCROW_ABI,
-  arg, hasFlag, argAll, loadApiKey, sendTx,
+  escrowContract, redactApiKey, BOUNTY_ESCROW_ABI, ESCROW, LINK,
+  arg, hasFlag, argAll, loadApiKey, sendTx, confirmSpendOrExit, isDryRun,
 } from './_lib.js';
 
 const jobId = arg('jobId');
@@ -46,7 +48,7 @@ const feeMaxFeeBasedScaling = arg('maxFeeBasedScaling');
 if (!jobId) {
   console.error('Usage: node submit_to_bounty.js --jobId <ID> --file <path> [--file <path2>] [--narrative "..."]');
   console.error('Optional: --alpha N --maxOracleFee N --estimatedBaseCost N --maxFeeBasedScaling N');
-  console.error('Flags:    --skip-confirm  --confirm-first');
+  console.error('Flags:    --skip-confirm  --confirm-first  --dry-run  --yes');
   process.exit(1);
 }
 if (files.length === 0) {
@@ -202,6 +204,24 @@ if (onChainBountyId != null) {
   console.warn(`  ⚠ Job not linked to chain (no onChain flag). Skipping on-chain pre-check.`);
 }
 
+if (isDryRun()) {
+  console.log('\nDry run complete: pre-flight checks passed.');
+  console.log('No files were uploaded and no transaction was signed.');
+  process.exit(0);
+}
+
+await confirmSpendOrExit([
+  `Action: submit work and sign Verdikta submission transactions`,
+  `Network: ${network}`,
+  `Hunter wallet: ${hunter}`,
+  `API: ${baseUrl}`,
+  `Job: #${jobId}`,
+  `Files to upload: ${files.join(', ')}`,
+  `Allowed escrow recipient: ${ESCROW[network]}`,
+  `Allowed LINK recipient: ${LINK[network]}`,
+  `Public data: uploaded work files may be pinned to IPFS and linked to on-chain submission metadata`,
+]);
+
 // ---- Step 1: Upload files to IPFS ----
 
 console.log('\n--- Step 1: Upload files to IPFS ---');
@@ -259,19 +279,23 @@ if (!prepareRes.ok || !prepareData.transaction) {
   process.exit(1);
 }
 
-const prepareReceipt = await sendTx(signer, 'prepareSubmission', prepareData.transaction);
+const prepareReceipt = await sendTx(signer, 'prepareSubmission', prepareData.transaction, {
+  expectedTo: ESCROW[network],
+  network,
+});
 
 // Parse SubmissionPrepared event (using centralized ABI)
 const escrowIface = new ethers.Interface(BOUNTY_ESCROW_ABI);
 
-let submissionId, evalWallet, linkMaxBudget;
+let submissionId, evalWallet, linkMaxBudget, linkMaxBudgetWei = null;
 for (const log of prepareReceipt.logs) {
   try {
     const parsed = escrowIface.parseLog(log);
     if (parsed?.name === 'SubmissionPrepared') {
       submissionId = Number(parsed.args.submissionId);
       evalWallet = parsed.args.evalWallet;
-      linkMaxBudget = ethers.formatEther(parsed.args.linkMaxBudget);
+      linkMaxBudgetWei = BigInt(parsed.args.linkMaxBudget);
+      linkMaxBudget = ethers.formatEther(linkMaxBudgetWei);
       break;
     }
   } catch {}
@@ -289,20 +313,28 @@ console.log(`  linkBudget:   ${linkMaxBudget} LINK`);
 
 // ---- Step 3: Approve LINK (on-chain tx 2/3) ----
 
-console.log('\n--- Step 3: Approve LINK to EvaluationWallet ---');
+if (linkMaxBudgetWei > 0n) {
+  console.log('\n--- Step 3: Approve LINK to EvaluationWallet ---');
 
-const approveRes = await fetch(`${baseUrl}/api/jobs/${jobId}/submit/approve`, {
-  method: 'POST',
-  headers: jsonHeaders,
-  body: JSON.stringify({ evalWallet, linkAmount: linkMaxBudget }),
-});
-const approveData = await approveRes.json();
-if (!approveRes.ok || !approveData.transaction) {
-  console.error('Approve failed:', JSON.stringify(approveData));
-  process.exit(1);
+  const approveRes = await fetch(`${baseUrl}/api/jobs/${jobId}/submit/approve`, {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify({ evalWallet, linkAmount: linkMaxBudget }),
+  });
+  const approveData = await approveRes.json();
+  if (!approveRes.ok || !approveData.transaction) {
+    console.error('Approve failed:', JSON.stringify(approveData));
+    process.exit(1);
+  }
+
+  await sendTx(signer, 'LINK approve', approveData.transaction, {
+    expectedTo: LINK[network],
+    network,
+  });
+} else {
+  console.log('\n--- Step 3: Skip LINK approval ---');
+  console.log('  Prepared submission reports zero LINK budget; modern ETH-funded start will use the API-provided payable transaction.');
 }
-
-await sendTx(signer, 'LINK approve', approveData.transaction);
 
 // ---- Steps 4 & 5: Start evaluation + Confirm in API ----
 //
@@ -341,7 +373,12 @@ async function doStart() {
     return { ok: false, data: startData, status: startRes.status };
   }
   // Use API-recommended gasLimit for start (typically 4M gas)
-  await sendTx(signer, 'startPreparedSubmission', startData.transaction, { useApiGasLimit: true });
+  await sendTx(signer, 'startPreparedSubmission', startData.transaction, {
+    useApiGasLimit: true,
+    expectedTo: ESCROW[network],
+    allowValue: true,
+    network,
+  });
   return { ok: true, data: startData };
 }
 

--- a/skills/verdikta-bounties-onboarding/scripts/swap_eth_to_link_0x.js
+++ b/skills/verdikta-bounties-onboarding/scripts/swap_eth_to_link_0x.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import './_env.js';
 import { Contract, formatEther } from 'ethers';
-import { getNetwork, providerFor, loadWallet, LINK, linkBalance, parseEth, arg } from './_lib.js';
+import {
+  getNetwork, providerFor, loadWallet, LINK, linkBalance, parseEth, arg,
+  hasFlag, sendTx, confirmSpendOrExit, isDryRun, expectedChainId,
+} from './_lib.js';
 
 const ethAmount = arg('eth');
 if (!ethAmount) {
-  console.error('Usage: node swap_eth_to_link_0x.js --eth 0.02');
+  console.error('Usage: node swap_eth_to_link_0x.js --eth 0.02 --yes');
+  console.error('Optional: --dry-run --allow-custom-0x');
   process.exit(1);
 }
 
@@ -21,8 +25,19 @@ const buyToken = LINK[network];
 
 const zeroX = process.env.ZEROX_BASE_URL || 'https://api.0x.org';
 const apiKey = process.env.ZEROX_API_KEY;
+const zeroXUrl = new URL(zeroX);
+
+if (zeroXUrl.hostname !== 'api.0x.org' && !hasFlag('allow-custom-0x')) {
+  console.error(`Refusing custom ZEROX_BASE_URL (${zeroX}) without --allow-custom-0x.`);
+  process.exit(1);
+}
 
 const provider = providerFor(network);
+const providerNetwork = await provider.getNetwork();
+if (Number(providerNetwork.chainId) !== expectedChainId(network)) {
+  console.error(`RPC chainId mismatch: got ${providerNetwork.chainId}, expected ${expectedChainId(network)} for ${network}. Refusing to swap.`);
+  process.exit(1);
+}
 const wallet = await loadWallet();
 const signer = wallet.connect(provider);
 
@@ -47,16 +62,62 @@ if (!resp.ok) {
 }
 const quote = await resp.json();
 
-// Send tx
-const tx = await signer.sendTransaction({
+if (!quote.to || typeof quote.to !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(quote.to)) {
+  throw new Error('0x quote missing valid transaction recipient');
+}
+if (!quote.data || !/^0x([0-9a-fA-F]{2})*$/.test(quote.data)) {
+  throw new Error('0x quote missing valid calldata');
+}
+if (quote.chainId != null && Number(quote.chainId) !== chainId) {
+  throw new Error(`0x quote chainId mismatch: got ${quote.chainId}, expected ${chainId}`);
+}
+if (quote.buyTokenAddress && quote.buyTokenAddress.toLowerCase() !== buyToken.toLowerCase()) {
+  throw new Error(`0x quote buy token mismatch: got ${quote.buyTokenAddress}, expected ${buyToken}`);
+}
+
+const txValue = BigInt(quote.value || sellAmountWei.toString());
+if (txValue > sellAmountWei) {
+  throw new Error(`0x quote value ${formatEther(txValue)} ETH exceeds requested sell amount ${formatEther(sellAmountWei)} ETH`);
+}
+
+console.log('\n0x swap quote');
+console.log(`Network:       ${network}`);
+console.log(`Wallet:        ${signer.address}`);
+console.log(`Sell:          ${formatEther(sellAmountWei)} ETH`);
+console.log(`Buy token:     ${buyToken}`);
+if (quote.buyAmount) console.log(`Quoted buy:    ${quote.buyAmount} LINK base units`);
+if (quote.estimatedPriceImpact) console.log(`Price impact:  ${quote.estimatedPriceImpact}`);
+console.log(`0x endpoint:   ${zeroXUrl.origin}`);
+console.log(`Tx recipient:  ${quote.to}`);
+console.log(`Tx value:      ${formatEther(txValue)} ETH`);
+
+if (isDryRun()) {
+  console.log('\nDry run complete: quote fetched and validated. No swap transaction was signed.');
+  process.exit(0);
+}
+
+await confirmSpendOrExit([
+  `Action: swap ETH to LINK through 0x aggregator calldata`,
+  `Network: ${network}`,
+  `Wallet: ${signer.address}`,
+  `Sell amount: ${formatEther(sellAmountWei)} ETH plus gas`,
+  `Buy token: ${buyToken}`,
+  `0x endpoint: ${zeroXUrl.origin}`,
+  `Transaction recipient: ${quote.to}`,
+]);
+
+await sendTx(signer, '0x ETH→LINK swap', {
   to: quote.to,
   data: quote.data,
-  value: BigInt(quote.value || sellAmountWei.toString()),
-  gasLimit: quote.gas ? BigInt(quote.gas) : undefined
+  value: txValue,
+  gasLimit: quote.gas ? BigInt(quote.gas) : undefined,
+  chainId,
+}, {
+  useApiGasLimit: Boolean(quote.gas),
+  allowValue: true,
+  maxValueWei: sellAmountWei,
+  network,
 });
-console.log('Sent swap tx:', tx.hash);
-const receipt = await tx.wait();
-console.log('Confirmed in block:', receipt.blockNumber);
 
 const { bal, dec, linkAddr } = await linkBalance(network, provider, signer.address);
 const link = new Contract(linkAddr, ['function symbol() view returns (string)'], provider);

--- a/skills/verdikta-bounties-onboarding/scripts/validate_contract_config.js
+++ b/skills/verdikta-bounties-onboarding/scripts/validate_contract_config.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Non-spending guardrail: verify local escrow defaults match the live agent docs.
+
+import './_env.js';
+import { ESCROW, getNetwork } from './_lib.js';
+
+const NETWORK_DOCS = {
+  base: 'https://bounties.verdikta.org/agents.txt',
+  'base-sepolia': 'https://bounties-testnet.verdikta.org/agents.txt',
+};
+
+const network = getNetwork();
+const docsUrl = NETWORK_DOCS[network];
+const localEscrow = ESCROW[network];
+
+if (!docsUrl || !localEscrow) {
+  console.error(`Unsupported network for contract validation: ${network}`);
+  process.exit(1);
+}
+
+const res = await fetch(docsUrl);
+if (!res.ok) {
+  console.error(`Failed to fetch ${docsUrl}: HTTP ${res.status}`);
+  process.exit(1);
+}
+
+const text = await res.text();
+const match = text.match(/BountyEscrow:\s*(0x[a-fA-F0-9]{40})/);
+if (!match) {
+  console.error(`Could not find BountyEscrow address in ${docsUrl}`);
+  process.exit(1);
+}
+
+const docsEscrow = match[1];
+if (docsEscrow.toLowerCase() !== localEscrow.toLowerCase()) {
+  console.error('BountyEscrow mismatch; refusing to validate config.');
+  console.error(`  Network:      ${network}`);
+  console.error(`  Local ESCROW: ${localEscrow}`);
+  console.error(`  Docs expect:  ${docsEscrow}`);
+  process.exit(1);
+}
+
+console.log(`BountyEscrow config OK (${network}): ${localEscrow}`);

--- a/skills/verdikta-bounties-onboarding/scripts/wallet_init.js
+++ b/skills/verdikta-bounties-onboarding/scripts/wallet_init.js
@@ -40,6 +40,7 @@ const out = resolvePath(outArg);
 
 await ensureDir(path.dirname(out));
 await fs.writeFile(out, json, { mode: 0o600 });
+await fs.chmod(out, 0o600);
 
 console.log(importMode ? 'Wallet imported and encrypted' : 'Bot wallet created');
 console.log('Address:', wallet.address);


### PR DESCRIPTION
## Summary
- update `verdikta-bounties-onboarding` Base escrow default to the contract currently advertised by the live Bounties API/docs
- also update Base Sepolia escrow default after the non-spending validator showed it was stale too
- add a fail-fast guard in `create_bounty.js` after API job creation and before on-chain spend: if the API-provided `job.contractAddress` differs from the local script escrow, exit before gas is spent
- add `validate_contract_config.js` plus npm scripts so agents can compare local escrow config against live `agents.txt` without creating a bounty or spending gas

## Incident context
A real mainnet test created API job `20` with evaluation CID `QmUfuP6Q1CqnGtva99z4t9Ef49mM9Gd4tRQA17LApMXvKC`, but the local script sent the on-chain transaction to the stale Base escrow default `0x3970dC3750DdE4E73fdcd3a81b66F1472BbaAEee` instead of the live API-expected contract `0x2ae271f5e86bee449a36b943414b7c1a7b39772d`.

Wrong-contract tx: `0xea5d0f339a05b51926db71ba55f622d31a18b74a2864b6eeedf64407983f95d0` (block `47462967`, old-contract bountyId `255`, amount `0.0028 ETH`). Link recovery correctly failed with `Wrong contract`.

This PR does **not** attempt recovery/close of that wrong-contract bounty.

## Validation
- `npm install` in `skills/verdikta-bounties-onboarding/scripts`
- `npm run check` ✅
  - syntax-checks all `*.js`
  - runs `node validate_contract_config.js` for Base against live `https://bounties.verdikta.org/agents.txt`
- `VERDIKTA_NETWORK=base-sepolia node validate_contract_config.js` ✅
- `git grep` confirmed the stale Base/Base-Sepolia escrow defaults are no longer present in the skill directory

No bounty creation, recovery, or gas-spending actions were performed while preparing this PR.
