### PR TITLE
docs: add Verdikta backlog workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md — Verdikta Applications
+
+Read this file before changing code, documentation, issues, or Project metadata
+for this repository. Human contributors should follow the same backlog rules.
+
+## Repository ownership
+
+`verdikta-applications` owns reference and production-facing application work,
+including the bounty escrow, bounty API and UI, dashboards, indexers, example
+frontends, and integration examples.
+
+Protocol aggregation belongs in `verdikta-dispatcher`; arbiter-node behavior in
+`verdikta-arbiter`; shared schemas and ClassID data in `verdikta-common`; and
+agent-runtime behavior in `verdikta-agents`. Cross-repository outcomes use a
+roadmap parent and repository-owned native sub-issues.
+
+## Verdikta backlog workflow (mandatory)
+
+- Project: [Verdikta Master Backlog](https://github.com/orgs/verdikta/projects/1)
+- Canonical guide: [Backlog and issue workflow](https://github.com/verdikta/verdikta-docs/blob/main/docs/backlog-workflow.md)
+
+Repository issues are the source of truth for work. The Project provides shared
+Status, Readiness, Priority, Size, Area, and roadmap progress. Never create a
+duplicate issue just to make work visible in the Project.
+
+### Navigate the backlog
+
+- **Top Priorities** answers what Verdikta should work on next.
+- **Agent Queue** shows `Ready` + `Todo` work, but is not automatic permission
+  to execute it.
+- **Execution Board** tracks active work by Status.
+- **Blocked** shows work requiring intervention.
+- **Roadmap** shows cross-repository initiatives and child progress.
+- **Master Backlog** is the complete inventory.
+
+### Before starting work
+
+1. Read the full issue, its parent initiative, dependencies, linked PRs, and
+   repository instructions.
+2. Search this repository and the organization for duplicates or superseding
+   work.
+3. Confirm the issue is in the Master Backlog and is owned by this repository.
+4. Confirm `Readiness = Ready`. If scope, acceptance criteria, validation, or a
+   decision is missing, keep or set `Needs Triage` and resolve the gap instead
+   of guessing.
+5. Confirm the requested action, permissions, and risk make autonomous work
+   appropriate. Agent Queue membership alone is insufficient.
+6. Assign the implementing GitHub identity when practical and set
+   `Status = In Progress` only when work actually begins.
+
+### While working and when finishing
+
+- Keep the issue's Scope and acceptance criteria aligned with the implementation.
+- Link the PR to the issue; use `Closes #123` only when completion of that PR
+  will satisfy the issue.
+- When blocked, set `Readiness = Blocked`, keep the truthful Status, and record
+  the blocker and removal condition in the issue.
+- Set `Status = Review` when the implementation or deliverable awaits review.
+- Set `Status = Done` and close the issue only after acceptance criteria and
+  validation are complete and accepted.
+- A merged PR alone is not proof that the issue is done.
+
+### Creating or maintaining issues
+
+- Implementation issues live here; roadmap initiative containers live in
+  `verdikta-roadmap` and carry the `initiative` label.
+- Search before creating. Prefer extending the canonical issue over filing a
+  differently worded duplicate.
+- New intake begins as `Status = Inbox`, `Readiness = Needs Triage`.
+- Mark work Ready only when its Goal, Context, Acceptance criteria, Validation,
+  and in/out Scope are objective enough to execute without guessing.
+- Use native parent/sub-issue relationships for cross-repository traceability.
+- Priority is Verdikta-wide, not repository-local.
+- Preserve the difference between execution Status and Readiness.
+- GitHub Assignee is the owner; do not add Owner Type.
+- Do not add calendar dates unless explicitly requested.
+- Do not copy Verdikta Bounties lifecycle state into GitHub.
+- Summarize proposed changes and obtain approval before bulk issue or Project
+  mutations.
+
+### Required Ready issue structure
+
+```markdown
+## Goal
+
+## Context
+
+## Acceptance criteria
+
+- [ ] Clear, testable condition
+
+## Validation
+
+## Scope
+
+In scope:
+
+- ...
+
+Out of scope:
+
+- ...
+```
+
+Use Project fields exactly as defined in the canonical guide: Status describes
+execution; Readiness describes workability; Priority is global importance; Size
+is rough effort; Area is functional domain.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A collection of reference applications demonstrating how to integrate with the Verdikta on-chain AI jury protocol. These applications showcase different approaches to building AI-powered evaluation systems using blockchain technology, IPFS, and multiple AI providers.
 
+## Backlog and contribution workflow
+
+Verdikta coordinates work across repositories through the
+[Verdikta Master Backlog](https://github.com/orgs/verdikta/projects/1).
+Humans and automated agents contributing here must read [AGENTS.md](AGENTS.md)
+and the canonical [backlog and issue workflow](https://github.com/verdikta/verdikta-docs/blob/main/docs/backlog-workflow.md)
+before creating, selecting, or changing work items.
+
 ## 🔍 What is Verdikta?
 
 Verdikta is a decentralized AI jury system that enables transparent, reliable, and consensus-driven evaluations. The protocol combines:
@@ -249,4 +257,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**Ready to build with Verdikta?** Start with our **[Getting Started Guide](docs/example-frontend/getting-started.md)** and join the future of decentralized AI evaluation! 🚀 
+**Ready to build with Verdikta?** Start with our **[Getting Started Guide](docs/example-frontend/getting-started.md)** and join the future of decentralized AI evaluation! 🚀


### PR DESCRIPTION
## Summary

- add or extend root `AGENTS.md` with mandatory Verdikta backlog rules
- document this repository's ownership boundary: bounty escrow, API/UI, dashboards, indexers, and reference application work
- add a human-facing README link to the Master Backlog and canonical workflow

## Why

Every agent and human contributor touching this repository should know how to find the global queue, distinguish initiatives from implementation issues, assess Ready work, maintain Status versus Readiness, avoid duplicates, link PRs, and close work only after acceptance.

Canonical guide PR: https://github.com/verdikta/verdikta-docs/pull/7

The canonical link targets `verdikta-docs/main`, so the documentation PR should merge before or with this PR.

## Validation

- `git diff --check`
- verified the README points to the root `AGENTS.md`, Master Backlog, and canonical guide
- verified the agent instructions include navigation, intake, Ready criteria, execution, blocking, completion, ownership, and bulk-mutation rules