### PR TITLE
Fix /rubric 404 for chain-synced bounties: derive + heal rubricCid from the evaluation package

### DIFF
--- a/example-bounty-program/server/routes/jobRoutes.js
+++ b/example-bounty-program/server/routes/jobRoutes.js
@@ -13,6 +13,7 @@ const fs = require('fs').promises;
 const AdmZip = require('adm-zip');
 const logger = require('../utils/logger');
 const jobStorage = require('../utils/jobStorage');
+const { packageRubricHash } = require('../utils/rubricSource');
 const { config } = require('../config');
 const archiveGenerator = require('../utils/archiveGenerator');
 const { validateRubric, validateJuryNodes, isValidFileType, MAX_FILE_SIZE,
@@ -3276,8 +3277,35 @@ router.get('/:jobId/rubric', async (req, res) => {
     logger.info('[jobs/rubric] get', { jobId });
 
     const job = await jobStorage.getJob(jobId);
+    const ipfsClient = req.app.locals.ipfsClient;
 
-    if (!job.rubricCid) {
+    // Effective rubric pointer. `job.rubricCid` is only a convenience cache:
+    // the chain-sync service never writes it, so bounties created directly
+    // on-chain arrive here with it empty even though their rubric exists in
+    // the (authoritative, immutable) evaluationCid package. When the cache is
+    // empty, derive the pointer from the package — the same direction
+    // scripts/healRubricCid.js repairs — and persist the heal so the next
+    // read is pointer-direct. (A stored pointer is served as-is; wrong-value
+    // drift remains the healer's offline job.)
+    let rubricCid = job.rubricCid || null;
+    if (!rubricCid && job.evaluationCid && ipfsClient) {
+      rubricCid = await packageRubricHash(ipfsClient, job.evaluationCid);
+      if (rubricCid) {
+        logger.info('[jobs/rubric] derived rubricCid from evaluationCid package (cache was empty)', {
+          jobId, rubricCid, evaluationCid: job.evaluationCid
+        });
+        try {
+          await jobStorage.updateJob(job.jobId, { rubricCid });
+        } catch (persistErr) {
+          // Best-effort: a failed write just means the next read re-derives.
+          logger.warn('[jobs/rubric] failed to persist healed rubricCid (still serving)', {
+            jobId, error: persistErr.message
+          });
+        }
+      }
+    }
+
+    if (!rubricCid) {
       return sendError(res, 404, {
         code: ErrorCodes.NOT_FOUND,
         message: 'No rubric available',
@@ -3286,7 +3314,6 @@ router.get('/:jobId/rubric', async (req, res) => {
       });
     }
 
-    const ipfsClient = req.app.locals.ipfsClient;
     if (!ipfsClient) {
       return sendError(res, 500, {
         code: ErrorCodes.INTERNAL_ERROR,
@@ -3299,19 +3326,19 @@ router.get('/:jobId/rubric', async (req, res) => {
     let rubricContent;
     try {
       const rawContent = await withTimeout(
-        ipfsClient.fetchFromIPFS(job.rubricCid),
+        ipfsClient.fetchFromIPFS(rubricCid),
         PIN_TIMEOUT_MS,
         'IPFS rubric fetch'
       );
       rubricContent = JSON.parse(rawContent);
     } catch (ipfsErr) {
-      logger.error('[jobs/rubric] IPFS fetch failed', { jobId, cid: job.rubricCid, msg: ipfsErr.message });
+      logger.error('[jobs/rubric] IPFS fetch failed', { jobId, cid: rubricCid, msg: ipfsErr.message });
       return sendError(res, 502, {
         code: ErrorCodes.INTERNAL_ERROR,
         message: 'Failed to fetch rubric from IPFS',
         details: ipfsErr.message,
-        fix: `You can try fetching directly from an IPFS gateway: https://ipfs.io/ipfs/${job.rubricCid}`,
-        extra: { rubricCid: job.rubricCid }
+        fix: `You can try fetching directly from an IPFS gateway: https://ipfs.io/ipfs/${rubricCid}`,
+        extra: { rubricCid }
       });
     }
 
@@ -3326,7 +3353,7 @@ router.get('/:jobId/rubric', async (req, res) => {
         workProductType: job.workProductType,
         threshold: job.threshold,
         classId: job.classId,
-        rubricCid: job.rubricCid,
+        rubricCid,
         submissionCloseTime: job.submissionCloseTime,
         status: job.status
       }

--- a/example-bounty-program/server/test/rubricRouteFallback.test.js
+++ b/example-bounty-program/server/test/rubricRouteFallback.test.js
@@ -1,0 +1,178 @@
+/**
+ * GET /api/jobs/:id/rubric — package-derive fallback for an empty rubricCid.
+ *
+ * The chain-sync service never writes the convenience-cache `rubricCid`, so
+ * bounties created directly on-chain 404'd this endpoint even though their
+ * rubric exists in the (authoritative) evaluationCid package — observed live
+ * on Base mainnet bounty 152 (2026-07-21): the evaluation page showed the
+ * rubric while /rubric returned "does not have a rubric CID".
+ *
+ * These tests pin the fix: an empty pointer is re-derived from
+ * manifest.additional[gradingRubric].hash, persisted back (read-side heal,
+ * same direction as scripts/healRubricCid.js), and served; a job whose
+ * package genuinely has no rubric still 404s; a stored pointer is served
+ * as-is with zero package fetches (no new IPFS cost on the common path).
+ */
+
+// ---------------------------------------------------------------------------
+// In-memory storage (must be prefixed with "mock" for jest.mock scope rules)
+// ---------------------------------------------------------------------------
+let mockStorageData = { jobs: [], nextId: 0 };
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      access: jest.fn().mockResolvedValue(undefined),
+      readFile: jest.fn().mockImplementation(() => Promise.resolve(JSON.stringify(mockStorageData))),
+      writeFile: jest.fn().mockImplementation((_path, data) => {
+        mockStorageData = JSON.parse(data);
+        return Promise.resolve();
+      }),
+      rename: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+jest.mock('../config', () => ({
+  config: {
+    network: 'base-sepolia',
+    bountyEscrowAddress: '0xabc123',
+    chainId: 84532,
+    explorer: 'https://sepolia.basescan.org',
+  },
+}));
+
+const express = require('express');
+const request = require('supertest');
+const AdmZip = require('adm-zip');
+const jobRoutes = require('../routes/jobRoutes');
+
+const RUBRIC_CID = 'QmRubricHashFromPackage111111111111111111111111';
+const EVAL_CID = 'QmEvaluationPackage22222222222222222222222222222';
+const RUBRIC_JSON = { version: 'rubric-1', title: 'Test rubric', criteria: [] };
+
+/** Build the evaluationCid archive: manifest.json referencing the rubric. */
+function evaluationZipBuffer({ withRubricRef = true } = {}) {
+  const zip = new AdmZip();
+  const manifest = {
+    version: '1.0',
+    juryParameters: { AI_NODES: [] },
+    additional: withRubricRef ? [{ name: 'gradingRubric', hash: RUBRIC_CID }] : [],
+  };
+  zip.addFile('manifest.json', Buffer.from(JSON.stringify(manifest)));
+  return zip.toBuffer();
+}
+
+function fakeIpfsClient(files) {
+  const calls = [];
+  return {
+    calls,
+    fetchFromIPFS: jest.fn(async (cid) => {
+      calls.push(cid);
+      if (cid in files) return files[cid];
+      throw new Error(`not pinned: ${cid}`);
+    }),
+  };
+}
+
+function buildApp(ipfsClient) {
+  const app = express();
+  app.use(express.json());
+  app.locals.ipfsClient = ipfsClient;
+  app.use('/jobs', jobRoutes);
+  return app;
+}
+
+function setStorage(job) {
+  mockStorageData = { jobs: [JSON.parse(JSON.stringify(job))], nextId: 1 };
+}
+
+function makeJob(overrides = {}) {
+  return {
+    jobId: 0,
+    title: 'Chain-synced bounty',
+    creator: '0xcreator',
+    bountyAmount: 0.01,
+    threshold: 92,
+    status: 'OPEN',
+    createdAt: Math.floor(Date.now() / 1000),
+    submissions: [],
+    onChain: true,
+    syncedFromBlockchain: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockStorageData = { jobs: [], nextId: 0 };
+});
+
+describe('GET /jobs/:id/rubric — package-derive fallback', () => {
+  it('derives the rubric from the evaluationCid package when rubricCid is empty (the chain-sync case)', async () => {
+    setStorage(makeJob({ evaluationCid: EVAL_CID /* no rubricCid — sync never writes it */ }));
+    const ipfs = fakeIpfsClient({
+      [EVAL_CID]: evaluationZipBuffer(),
+      [RUBRIC_CID]: Buffer.from(JSON.stringify(RUBRIC_JSON)),
+    });
+
+    const res = await request(buildApp(ipfs)).get('/jobs/0/rubric');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.rubric).toEqual(RUBRIC_JSON);
+    expect(res.body.meta.rubricCid).toBe(RUBRIC_CID);
+  });
+
+  it('persists the derived pointer (read-side heal) so the next read skips the package', async () => {
+    setStorage(makeJob({ evaluationCid: EVAL_CID }));
+    const ipfs = fakeIpfsClient({
+      [EVAL_CID]: evaluationZipBuffer(),
+      [RUBRIC_CID]: Buffer.from(JSON.stringify(RUBRIC_JSON)),
+    });
+    const app = buildApp(ipfs);
+
+    await request(app).get('/jobs/0/rubric').expect(200);
+    // The heal round-tripped through real jobStorage into "disk".
+    expect(mockStorageData.jobs[0].rubricCid).toBe(RUBRIC_CID);
+
+    // Second read: pointer-direct — the package archive is not re-fetched.
+    const callsBefore = ipfs.calls.filter((c) => c === EVAL_CID).length;
+    await request(app).get('/jobs/0/rubric').expect(200);
+    expect(ipfs.calls.filter((c) => c === EVAL_CID).length).toBe(callsBefore);
+  });
+
+  it('still 404s when the package genuinely has no gradingRubric reference', async () => {
+    setStorage(makeJob({ evaluationCid: EVAL_CID }));
+    const ipfs = fakeIpfsClient({ [EVAL_CID]: evaluationZipBuffer({ withRubricRef: false }) });
+
+    const res = await request(buildApp(ipfs)).get('/jobs/0/rubric');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('No rubric available');
+    expect(mockStorageData.jobs[0].rubricCid).toBeUndefined(); // nothing healed
+  });
+
+  it('404s (rather than throwing) when the package fetch itself fails', async () => {
+    setStorage(makeJob({ evaluationCid: EVAL_CID }));
+    const ipfs = fakeIpfsClient({}); // every fetch rejects
+
+    const res = await request(buildApp(ipfs)).get('/jobs/0/rubric');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('serves a stored rubricCid pointer-direct with zero package fetches (unchanged fast path)', async () => {
+    setStorage(makeJob({ evaluationCid: EVAL_CID, rubricCid: RUBRIC_CID }));
+    const ipfs = fakeIpfsClient({ [RUBRIC_CID]: Buffer.from(JSON.stringify(RUBRIC_JSON)) });
+
+    const res = await request(buildApp(ipfs)).get('/jobs/0/rubric');
+
+    expect(res.status).toBe(200);
+    expect(res.body.rubric).toEqual(RUBRIC_JSON);
+    expect(ipfs.calls).toEqual([RUBRIC_CID]); // never touched the archive
+  });
+});

--- a/example-bounty-program/server/utils/rubricSource.js
+++ b/example-bounty-program/server/utils/rubricSource.js
@@ -1,0 +1,51 @@
+/**
+ * Authoritative rubric-pointer derivation.
+ *
+ * The on-chain `evaluationCid` package is content-addressed/immutable and is
+ * exactly what the oracle grades against; its manifest.additional entry named
+ * `gradingRubric` carries the authoritative rubric hash. The loose top-level
+ * `job.rubricCid` field is only a convenience cache: the chain-sync service
+ * never writes it (so bounties created directly on-chain arrive with it
+ * empty), and heals/renumbers have historically let it drift (see
+ * scripts/healRubricCid.js and the bounty-247 postmortem in its header).
+ *
+ * This helper is the shared read-side primitive for re-deriving the pointer
+ * from the package. It intentionally NEVER throws: a null return means "the
+ * package gave nothing" (no/invalid archive, no manifest, no gradingRubric
+ * reference, or an IPFS fetch failure) and callers fall back to whatever
+ * behavior they had before deriving.
+ */
+
+const AdmZip = require('adm-zip');
+const logger = require('./logger');
+
+/**
+ * Derive the gradingRubric hash referenced inside an evaluationCid package.
+ *
+ * @param {{ fetchFromIPFS(cid: string): Promise<Buffer> }} ipfsClient
+ * @param {string} evaluationCid  the job's on-chain evaluation package CID
+ * @returns {Promise<string|null>} the rubric CID, or null if underivable
+ */
+async function packageRubricHash(ipfsClient, evaluationCid) {
+  if (!ipfsClient || !evaluationCid) return null;
+  try {
+    const archiveBuffer = await ipfsClient.fetchFromIPFS(evaluationCid);
+    const zip = new AdmZip(archiveBuffer);
+    const entries = zip.getEntries();
+    const manifestEntry = entries.find(
+      (e) => e.entryName === 'manifest.json' || e.entryName.endsWith('/manifest.json')
+    );
+    if (!manifestEntry) return null;
+    const manifest = JSON.parse(zip.readAsText(manifestEntry));
+    const gradingRubricRef = manifest.additional?.find((a) => a.name === 'gradingRubric');
+    return gradingRubricRef?.hash || null;
+  } catch (err) {
+    logger.warn('[rubricSource] failed to derive rubric hash from evaluationCid package', {
+      evaluationCid,
+      msg: err.message,
+    });
+    return null;
+  }
+}
+
+module.exports = { packageRubricHash };


### PR DESCRIPTION
## Problem (observed live, Base mainnet bounty 152, 2026-07-21)

`GET /api/jobs/152/rubric` returned 404 ("does not have a rubric CID") while the bounty's evaluation page displayed the full rubric — because the page derives from the **evaluationCid package** (authoritative, what oracles grade against) while `/rubric` reads the loose `job.rubricCid` **convenience cache**, which the chain-sync service never writes. Every bounty created directly on-chain therefore 404s this endpoint until `scripts/healRubricCid.js` is run offline. Downstream, verdikta-agents' per-agent health probes treat `/rubric` as canonical and flagged every agent Degraded when a rubric-less-cache bounty reached the head of the open list.

## Fix (read-side heal, minimal surface)

When the stored pointer is **empty** and the job has an `evaluationCid`, the route now:
1. derives `manifest.additional[gradingRubric].hash` from the package via a new shared helper (`utils/rubricSource.js`, never throws — `null` = "package gave nothing"),
2. **persists the heal** through `jobStorage.updateJob` (best-effort, race-safe — same write path as the Option-B rubric cache), so the next read is pointer-direct,
3. serves the rubric exactly as before.

Deliberately narrow:
- A **stored** pointer keeps the exact old fast path — zero package fetches, no behavior change.
- A package with no `gradingRubric` reference (or a failed package fetch) still 404s with the original message + fix-hint.
- **Wrong-value** drift (the bounty-247 class) is untouched — that stays the offline healer's judgment call; this route only fills the *missing*-pointer case, in the same authoritative direction the healer repairs.

## Tests

`test/rubricRouteFallback.test.js` — 5 supertest pins on the real router + real jobStorage over the mocked-fs harness (same pattern as `windowedSubmission.test.js`): derive-and-serve; heal persistence + no archive re-fetch on the second read; genuine-no-rubric 404 with nothing healed; package-fetch-failure 404; stored-pointer path makes exactly one IPFS call. **Full server suite: 85/85** (was 80).

## Notes

- `healRubricCid.js` remains useful for bulk backfill and wrong-pointer repair; this PR just stops the missing-pointer case from recurring per-bounty.
- Bounty 152 self-heals on the first `/rubric` request after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)