### PR TITLE
fix(validate): treat terminal bounties as INFO not ERROR (issue #14)

### DIFF
--- a/example-bounty-program/client/src/pages/Home.jsx
+++ b/example-bounty-program/client/src/pages/Home.jsx
@@ -502,6 +502,10 @@ function JobCard({ job, ethPrice }) {
   const isExpired = status === BountyStatus.EXPIRED;
   const isAwarded = status === BountyStatus.AWARDED;
   const isClosed = status === BountyStatus.CLOSED;
+  // EXPIRED/AWARDED/CLOSED are terminal — the bounty can no longer accept
+  // submissions or pay out, so the Validate button is replaced with a neutral
+  // "Completed" badge. Mirrors TERMINAL_BOUNTY_STATUSES on the server side.
+  const isTerminal = isAwarded || isClosed || isExpired;
 
   // Pending-on-chain: API-created but not yet confirmed by the sync service
   // and not marked ORPHANED. Shown briefly (< 1h) while the creation tx is
@@ -613,6 +617,19 @@ function JobCard({ job, ethPrice }) {
                 Pending on-chain
               </span>
             )}
+            {isTerminal ? (
+              <span
+                className="badge badge-completed"
+                title={isAwarded
+                  ? 'Awarded — this bounty has been paid out and is no longer actionable.'
+                  : isClosed
+                    ? 'Closed — this bounty was cancelled without a winner; funds returned.'
+                    : 'Expired — submission window has passed.'}
+              >
+                <Check size={12} style={{ verticalAlign: 'middle', marginRight: '2px' }} />
+                Completed
+              </span>
+            ) : (
             <div className="validate-row">
               {/* Validation status indicator - next to validate button */}
               {validationResult ? (
@@ -673,6 +690,7 @@ function JobCard({ job, ethPrice }) {
                 </span>
               </button>
             </div>
+            )}
           </div>
         </div>
       </div>

--- a/example-bounty-program/server/routes/jobRoutes.js
+++ b/example-bounty-program/server/routes/jobRoutes.js
@@ -19,7 +19,7 @@ const { validateRubric, validateJuryNodes, isValidFileType, MAX_FILE_SIZE,
         oracleUnreadableReason, detectBinaryContainer, ALLOWED_ZIP_BASED_EXTENSIONS,
         parseFeeToWei, extractEvaluationWarnings } = require('../utils/validation');
 const { getVerdiktaService, isVerdiktaServiceAvailable } = require('../utils/verdiktaService');
-const { validateBounty, IssueSeverity, IssueType } = require('../utils/bountyValidator');
+const { validateBounty, IssueSeverity, IssueType, chainStatusIssue } = require('../utils/bountyValidator');
 const { getContractService } = require('../utils/contractService');
 const { sendError, ErrorCodes } = require('../utils/apiErrors');
 
@@ -2075,13 +2075,12 @@ router.get('/:jobId/validate', async (req, res) => {
       const contractService = getContractService();
       const onChain = await contractService.getBounty(job.jobId);
 
-      if (onChain.status !== 'OPEN') {
-        result.issues.push({
-          type: IssueType.CHAIN_STATUS,
-          severity: IssueSeverity.ERROR,
-          message: `Bounty is "${onChain.status}" on-chain and cannot accept submissions or pay out.`
-        });
-        result.valid = false;
+      const chainCheck = chainStatusIssue(onChain.status);
+      if (chainCheck) {
+        result.issues.push(chainCheck.issue);
+        if (chainCheck.invalidatesPackage) {
+          result.valid = false;
+        }
       }
     } catch (chainErr) {
       const msg = chainErr.message || '';

--- a/example-bounty-program/server/test/validateTerminalState.test.js
+++ b/example-bounty-program/server/test/validateTerminalState.test.js
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for issue #14 — Validate returns red error for AWARDED
+ * (and other terminal) bounties, making every successfully-completed bounty
+ * look defective on the board.
+ *
+ * Two angles covered:
+ *  1. Pure-function unit tests for `chainStatusIssue()` so the mapping
+ *     "OPEN → no issue, terminal → info, unknown → error" is
+ *     independently locked in.
+ *  2. Integration tests for GET /:jobId/validate that mock the on-chain
+ *     `getBounty` response for each of the four real on-chain states plus
+ *     an unknown state, asserting the right severity / valid combination.
+ */
+
+// ---------------------------------------------------------------------------
+// In-memory storage (must be prefixed with "mock" for jest.mock scope rules)
+// ---------------------------------------------------------------------------
+let mockStorageData = { jobs: [], nextId: 0 };
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      access: jest.fn().mockResolvedValue(undefined),
+      readFile: jest.fn().mockImplementation(() => Promise.resolve(JSON.stringify(mockStorageData))),
+      writeFile: jest.fn().mockImplementation((_path, data) => {
+        mockStorageData = JSON.parse(data);
+        return Promise.resolve();
+      }),
+      rename: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+jest.mock('../config', () => ({
+  config: {
+    network: 'base-sepolia',
+    bountyEscrowAddress: '0xabc123',
+    chainId: 84532,
+    explorer: 'https://sepolia.basescan.org',
+  },
+}));
+
+// Replace the format-checker with a fixed "format is valid" result so the
+// tests isolate ONLY the on-chain-status branch behaviour.
+jest.mock('../utils/bountyValidator', () => {
+  const actual = jest.requireActual('../utils/bountyValidator');
+  return {
+    ...actual,
+    // Fresh object per call: the route mutates result.issues/result.valid in
+    // place, so caching the same {issues: []} would leak state between tests.
+    validateBounty: jest.fn().mockImplementation(() => Promise.resolve({ valid: true, issues: [] })),
+  };
+});
+
+// Configurable on-chain bounty read. Tests set this per-case.
+let mockGetBounty = jest.fn();
+jest.mock('../utils/contractService', () => ({
+  getContractService: () => ({ getBounty: (...args) => mockGetBounty(...args) }),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const {
+  chainStatusIssue,
+  isTerminalBountyStatus,
+  IssueSeverity,
+  IssueType,
+  TERMINAL_BOUNTY_STATUSES,
+} = require('../utils/bountyValidator');
+const jobRoutes = require('../routes/jobRoutes');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  // The real route handler reads ipfsClient from app.locals; supply a stub so
+  // the handler never reaches an "IPFS client not available" 500 even though
+  // we mocked out the only consumer (validateBounty).
+  app.locals.ipfsClient = { fetchFromIPFS: jest.fn() };
+  app.use('/jobs', jobRoutes);
+  return app;
+}
+
+const NOW = () => Math.floor(Date.now() / 1000);
+
+function setStorage(job) {
+  mockStorageData = { jobs: [JSON.parse(JSON.stringify(job))], nextId: 1 };
+}
+
+function makeJob(overrides = {}) {
+  return {
+    jobId: 106,
+    title: 'Completed Bounty',
+    creator: '0xcreator',
+    bountyAmount: 0.005,
+    threshold: 90,
+    evaluationCid: 'QmTestCidForValidate',
+    status: 'OPEN',
+    createdAt: NOW(),
+    submissionCount: 1,
+    submissions: [],
+    contractAddress: '0xabc123',
+    onChain: true,
+    syncedFromBlockchain: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockStorageData = { jobs: [], nextId: 0 };
+  mockGetBounty = jest.fn();
+});
+
+describe('chainStatusIssue() helper (pure-function mapping)', () => {
+  it('returns null for OPEN so we never add an issue for active bounties', () => {
+    expect(chainStatusIssue('OPEN')).toBeNull();
+  });
+
+  it('returns null for null/undefined input (defensive against missing chain read)', () => {
+    expect(chainStatusIssue(null)).toBeNull();
+    expect(chainStatusIssue(undefined)).toBeNull();
+  });
+
+  for (const terminal of ['EXPIRED', 'AWARDED', 'CLOSED']) {
+    it(`classifies ${terminal} as INFO + does NOT invalidate the package`, () => {
+      const out = chainStatusIssue(terminal);
+      expect(out).not.toBeNull();
+      expect(out.issue.type).toBe(IssueType.CHAIN_STATUS);
+      expect(out.issue.severity).toBe(IssueSeverity.INFO);
+      expect(out.invalidatesPackage).toBe(false);
+      expect(out.issue.message).toContain(terminal);
+      // Crucial: not ERROR. The bug was that all non-OPEN statuses were ERROR.
+      expect(out.issue.severity).not.toBe(IssueSeverity.ERROR);
+    });
+  }
+
+  it('classifies unknown statuses as ERROR and DOES invalidate the package', () => {
+    const out = chainStatusIssue('SOMETHING_NEW');
+    expect(out).not.toBeNull();
+    expect(out.issue.severity).toBe(IssueSeverity.ERROR);
+    expect(out.invalidatesPackage).toBe(true);
+  });
+});
+
+describe('isTerminalBountyStatus() set membership', () => {
+  it('is true exactly for EXPIRED/AWARDED/CLOSED', () => {
+    expect(TERMINAL_BOUNTY_STATUSES.has('EXPIRED')).toBe(true);
+    expect(TERMINAL_BOUNTY_STATUSES.has('AWARDED')).toBe(true);
+    expect(TERMINAL_BOUNTY_STATUSES.has('CLOSED')).toBe(true);
+  });
+  it('is false for OPEN and any other string', () => {
+    expect(isTerminalBountyStatus('OPEN')).toBe(false);
+    expect(isTerminalBountyStatus('WHATEVER')).toBe(false);
+    expect(isTerminalBountyStatus('')).toBe(false);
+    expect(isTerminalBountyStatus(null)).toBe(false);
+    expect(isTerminalBountyStatus(undefined)).toBe(false);
+    expect(isTerminalBountyStatus(123)).toBe(false);
+  });
+});
+
+describe('GET /:jobId/validate — issue #14 terminal-state classification', () => {
+  // The exact on-chain truth nigelon cited in the issue body.
+  const JOBID = 106;
+
+  it('OPEN bounties return valid:true with no CHAIN_STATUS issue', async () => {
+    setStorage(makeJob({ jobId: JOBID }));
+    mockGetBounty.mockResolvedValue({ status: 'OPEN' });
+
+    const res = await request(buildApp()).get(`/jobs/${JOBID}/validate`);
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.issues.find((i) => i.type === IssueType.CHAIN_STATUS)).toBeUndefined();
+  });
+
+  for (const [name, chainStatus] of [
+    ['EXPIRED', 'EXPIRED'],
+    ['AWARDED', 'AWARDED'],
+    ['CLOSED', 'CLOSED'],
+  ]) {
+    it(`${name}: valid:true with an INFO CHAIN_STATUS issue (does NOT look defective)`, async () => {
+      setStorage(makeJob({ jobId: JOBID }));
+      mockGetBounty.mockResolvedValue({ status: chainStatus });
+
+      const res = await request(buildApp()).get(`/jobs/${JOBID}/validate`);
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(true);
+      const chainIssue = res.body.issues.find((i) => i.type === IssueType.CHAIN_STATUS);
+      expect(chainIssue).toBeDefined();
+      expect(chainIssue.severity).toBe(IssueSeverity.INFO);
+      // Most importantly: completed bounties no longer raise the red-error chip.
+      expect(chainIssue.severity).not.toBe(IssueSeverity.ERROR);
+      expect(res.body.issues.filter((i) => i.severity === IssueSeverity.ERROR)).toHaveLength(0);
+    });
+  }
+
+  it('unknown on-chain status still raises ERROR + invalidates (legacy behaviour preserved)', async () => {
+    setStorage(makeJob({ jobId: JOBID }));
+    mockGetBounty.mockResolvedValue({ status: 'SOMETHING_NEW' });
+
+    const res = await request(buildApp()).get(`/jobs/${JOBID}/validate`);
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    const chainIssue = res.body.issues.find((i) => i.type === IssueType.CHAIN_STATUS);
+    expect(chainIssue).toBeDefined();
+    expect(chainIssue.severity).toBe(IssueSeverity.ERROR);
+  });
+
+  it('returns NOT_ON_CHAIN with ERROR severity when the chain read fails with bad bountyId', async () => {
+    setStorage(makeJob({ jobId: JOBID }));
+    mockGetBounty.mockRejectedValue(new Error('bad bountyId: not found'));
+
+    const res = await request(buildApp()).get(`/jobs/${JOBID}/validate`);
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    const issue = res.body.issues.find((i) => i.type === IssueType.NOT_ON_CHAIN);
+    expect(issue).toBeDefined();
+    expect(issue.severity).toBe(IssueSeverity.ERROR);
+  });
+});

--- a/example-bounty-program/server/utils/bountyValidator.js
+++ b/example-bounty-program/server/utils/bountyValidator.js
@@ -37,6 +37,56 @@ const IssueType = {
 };
 
 /**
+ * On-chain bounty states that are terminal — the contract can no longer
+ * accept submissions or pay out, regardless of whether the evaluation
+ * package itself is well-formed. Used by callers (e.g. GET /:jobId/validate)
+ * to avoid flagging a perfectly fine package as an ERROR just because the
+ * bounty has already concluded. Mirrors the BountyStatus enum exported
+ * from client/src/utils/statusDisplay.js (OPEN / EXPIRED / AWARDED / CLOSED).
+ */
+const TERMINAL_BOUNTY_STATUSES = new Set(['EXPIRED', 'AWARDED', 'CLOSED']);
+
+/**
+ * True when the given on-chain status string represents a terminal state.
+ * Anything that is not in the set (including OPEN and unknown values) is
+ * treated as non-terminal — callers should keep their stricter checks for
+ * those.
+ */
+function isTerminalBountyStatus(status) {
+  return typeof status === 'string' && TERMINAL_BOUNTY_STATUSES.has(status);
+}
+
+/**
+ * Pick the right (severity, valid) outcome for a validate-time chain-status
+ * issue. Terminal states get INFO severity and do not invalidate the
+ * package; unknown statuses keep the legacy ERROR behavior so genuinely
+ * broken bounties are still flagged. Returns null when no issue should
+ * be pushed (status === 'OPEN').
+ */
+function chainStatusIssue(status) {
+  if (status === 'OPEN' || status == null) return null;
+  if (isTerminalBountyStatus(status)) {
+    return {
+      issue: {
+        type: IssueType.CHAIN_STATUS,
+        severity: IssueSeverity.INFO,
+        message: `Bounty is "${status}" on-chain and is no longer accepting submissions or paying out.`
+      },
+      invalidatesPackage: false
+    };
+  }
+  return {
+    issue: {
+      type: IssueType.CHAIN_STATUS,
+      severity: IssueSeverity.ERROR,
+      message: `Bounty is "${status}" on-chain and cannot accept submissions or pay out.`
+    },
+    invalidatesPackage: true
+  };
+}
+
+/**
+/**
  * Check if content is a ZIP file by examining magic bytes
  * @param {Buffer} content - Content to check
  * @returns {boolean}
@@ -391,4 +441,13 @@ module.exports = {
   isZipFile,
   IssueSeverity,
   IssueType
+};
+
+module.exports = {
+  ...module.exports,
+  IssueSeverity,
+  IssueType,
+  TERMINAL_BOUNTY_STATUSES,
+  isTerminalBountyStatus,
+  chainStatusIssue,
 };


### PR DESCRIPTION
Fixes #14.

The `GET /api/jobs/:jobId/validate` route used `severity: error` for every on-chain status that wasn't `OPEN`. EXPIRED, AWARDED, and CLOSED are normal terminal states — the evaluation package can still be perfectly well-formed; the contract simply won't accept new submissions or pay out. With the prior behaviour every successfully completed bounty rendered a red error chip on the bounty board, making healthy cards look defective.

## What changes

- **server/utils/bountyValidator.js** — add `TERMINAL_BOUNTY_STATUSES`, `isTerminalBountyStatus()`, and a `chainStatusIssue()` helper that maps:
  - `OPEN`          → no issue pushed
  - `EXPIRED`/`AWARDED`/`CLOSED` → severity=info, package stays valid
  - any other status → severity=error + package flagged invalid (legacy behaviour preserved)
- **server/routes/jobRoutes.js** — `/:jobId/validate` now calls `chainStatusIssue()` instead of the blanket non-`OPEN` branch.
- **client/src/pages/Home.jsx** — when the job card is in a terminal state the **Validate** button is replaced by a neutral "Completed" badge with a state-aware tooltip ("Awarded — paid out…", "Closed — funds returned…", or "Expired — submission window has passed"). Active bounties keep the existing button + status icon behaviour untouched.
- **server/test/validateTerminalState.test.js** — 14 new jest tests covering the pure-function mapping, route-level behaviour across OPEN/EXPIRED/AWARDED/CLOSED/unknown/bad-bountyId, and the existing ERROR path.

## Verification

```bash
cd example-bounty-program/server
npx jest
```

→ `Test Suites: 9 passed, Tests: 81 passed` (the new file contributes 14 of those; everything existing still passes).

## Out of scope / follow-ups

- The new `badge-completed` class isn't styled yet — happy to add a neutral grey pill in a follow-up if you want the visual polish before merge.
- I don't see a stated reward for non-bounty-board issue fixes. Left a note on the issue asking about the payment path. If you usually fund this kind of work through a bounties-board listing, point me at it and I'll wrap the work into that flow rather than this PR.